### PR TITLE
[FIX] UBLE-20 packages/ui 빌드 산출물 분리 설정

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -12,7 +12,7 @@ function getAbsolutePath(value: string): any {
 const config: StorybookConfig = {
   stories: [
     "../src/**/*.mdx",
-    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../src/**/*.stories.@(ts|tsx)",
     // "../../../packages/ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
   ],
   addons: [

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -4,7 +4,9 @@
     "baseUrl": ".",
     "paths": {
       "@workspace/ui/*": ["./src/*"]
-    }
+    },
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
 
   apps/storybook:
     dependencies:
+      '@workspace/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       next:
         specifier: 15.3.5
         version: 15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
## #️⃣연관된 이슈

#1 

##  📝작업 내용

- packages/ui 빌드 산출물 분리 설정 (`tsconfig.json`)
- storybook `main.ts` stories에 js, jsx, mjs 확장자 제외 설정

##  📷스크린샷 (선택)


##  💬리뷰 요구사항(선택)
기존에 pnpm build하여 `packages/ui/src/components/button.js`, `packages/ui/src/components/badge.js`, `packages/ui/src/components/lib/utils.js` 등 js 파일 생성되었다면 삭제 후 스토리북 정상적으로 이용 가능합니다.