### PR TITLE
[FEAT] UBLE-41 role이 TMP_USER일 경우 유저 추가 정보 저장 구현

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack -p 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/apps/storybook/src/stories/DynamicCard.stories.ts
+++ b/apps/storybook/src/stories/DynamicCard.stories.ts
@@ -1,4 +1,4 @@
-import React from "react";
+
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { fn } from "storybook/test";
 

--- a/apps/user/package.json
+++ b/apps/user/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p 3000",
+    "dev": "next dev --turbopack -p 3000 --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/apps/user/src/app/(main)/home/components/AgeSection.tsx
+++ b/apps/user/src/app/(main)/home/components/AgeSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+
 import SectionHeader from "@/components/ui/SectionHeader";
 import DynamicCard from "@/components/ui/DynamicCard";
 import { BrandContent } from "@/types/brand";

--- a/apps/user/src/app/(main)/home/components/EntireSection.tsx
+++ b/apps/user/src/app/(main)/home/components/EntireSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+
 import DynamicCard from "@/components/ui/DynamicCard";
 import { BrandContent } from "@/types/brand";
 import SectionHeader from "@/components/ui/SectionHeader";

--- a/apps/user/src/app/(main)/home/components/PersonalSection.tsx
+++ b/apps/user/src/app/(main)/home/components/PersonalSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+
 import SectionHeader from "@/components/ui/SectionHeader";
 import DynamicCard from "@/components/ui/DynamicCard";
 import { BrandContent } from "@/types/brand";

--- a/apps/user/src/app/(main)/home/components/SearchSection.tsx
+++ b/apps/user/src/app/(main)/home/components/SearchSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 import SearchInput from '@/components/common/SearchInput';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 const SearchSection = () => {
   const [searchQuery, setSearchQuery] = useState('');

--- a/apps/user/src/app/(main)/home/components/TimeSection.tsx
+++ b/apps/user/src/app/(main)/home/components/TimeSection.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 import SectionHeader from "@/components/ui/SectionHeader";
 import DynamicCard from "@/components/ui/DynamicCard";
 import { BrandContent } from "@/types/brand";

--- a/apps/user/src/app/(main)/home/components/ui/MembershipGrade.tsx
+++ b/apps/user/src/app/(main)/home/components/ui/MembershipGrade.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+
 // import { GRADE_COLORS } from '@/types/constants';
 import { BrandContent } from "@/types/brand";
 

--- a/apps/user/src/app/(main)/home/page.tsx
+++ b/apps/user/src/app/(main)/home/page.tsx
@@ -1,7 +1,7 @@
 import AgeSection from "@/app/(main)/home/components/AgeSection";
 import PersonalSection from "@/app/(main)/home/components/PersonalSection";
 import TimeSection from "@/app/(main)/home/components/TimeSection";
-import React from "react";
+
 import EntireSection from "./components/EntireSection";
 import SearchSection from "./components/SearchSection";
 

--- a/apps/user/src/app/(main)/mypage/components/BenefitListBtn.tsx
+++ b/apps/user/src/app/(main)/mypage/components/BenefitListBtn.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React from 'react';
+
 import { useRouter } from 'next/navigation';
 import { ChevronRight, Gift } from 'lucide-react';
 

--- a/apps/user/src/app/(main)/mypage/components/FeedbackBtn.tsx
+++ b/apps/user/src/app/(main)/mypage/components/FeedbackBtn.tsx
@@ -1,5 +1,5 @@
 import { ChevronRight, MessageSquare } from 'lucide-react';
-import React from 'react';
+
 
 const FeedbackBtn = () => {
   return (

--- a/apps/user/src/app/(main)/mypage/components/LogoutBtn.tsx
+++ b/apps/user/src/app/(main)/mypage/components/LogoutBtn.tsx
@@ -2,7 +2,7 @@
 import { Button } from '@workspace/ui/components/button';
 import { LogOut } from 'lucide-react';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 const LogoutBtn = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/apps/user/src/app/(main)/mypage/components/ProfileInfo.tsx
+++ b/apps/user/src/app/(main)/mypage/components/ProfileInfo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 
 import { UserInfo } from '@/types/profile';
 import { Badge } from '@workspace/ui/components/badge';

--- a/apps/user/src/app/(main)/mypage/components/ProfileStatistics.tsx
+++ b/apps/user/src/app/(main)/mypage/components/ProfileStatistics.tsx
@@ -1,6 +1,6 @@
 import { UserStatistics } from '@/types/profile';
 import { BarChart3 } from 'lucide-react';
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 
 const ProfileStatistics = () => {
   const userStats: UserStatistics = {

--- a/apps/user/src/app/(main)/mypage/components/WithdrawBtn.tsx
+++ b/apps/user/src/app/(main)/mypage/components/WithdrawBtn.tsx
@@ -2,7 +2,7 @@
 import { Button } from '@workspace/ui/components/button';
 import { UserX } from 'lucide-react';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 const WithdrawBtn = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/apps/user/src/app/(main)/mypage/components/ui/ProfileCard.tsx
+++ b/apps/user/src/app/(main)/mypage/components/ui/ProfileCard.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent } from '@workspace/ui/components/card';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 interface ProfileCardProps {
   children: ReactNode;

--- a/apps/user/src/app/(main)/mypage/history/components/BenefitList.tsx
+++ b/apps/user/src/app/(main)/mypage/history/components/BenefitList.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { Fragment, useState } from 'react';
+import { Fragment, useState } from 'react';
 import BenefitStatistics from './BenefitStatistics';
 import { benefitHistory } from './testData';
 import BenefitListItem from './BenefitListItem';

--- a/apps/user/src/app/(main)/mypage/history/components/BenefitListItem.tsx
+++ b/apps/user/src/app/(main)/mypage/history/components/BenefitListItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import { memo } from 'react';
 import { Benefit } from '@/types/benefit';
 import BenefitCard from './ui/BenefitCard';
 import { Badge } from '@workspace/ui/components/badge';

--- a/apps/user/src/app/(main)/mypage/history/components/BenefitStatistics.tsx
+++ b/apps/user/src/app/(main)/mypage/history/components/BenefitStatistics.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 
 interface BenefitStatisticsProps {
   listSize: number;

--- a/apps/user/src/app/(main)/mypage/history/components/PeriodFilter.tsx
+++ b/apps/user/src/app/(main)/mypage/history/components/PeriodFilter.tsx
@@ -1,6 +1,6 @@
 import { periodOptions } from "@/types/constants";
 import { Button } from "@workspace/ui/components/button";
-import React, { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction } from "react";
 
 interface PeriodFilterProps {
   period: string;

--- a/apps/user/src/app/(main)/mypage/history/components/ui/BenefitCard.tsx
+++ b/apps/user/src/app/(main)/mypage/history/components/ui/BenefitCard.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent } from '@workspace/ui/components/card';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 interface BenefitCardProps {
   children: ReactNode;

--- a/apps/user/src/app/(main)/mypage/history/page.tsx
+++ b/apps/user/src/app/(main)/mypage/history/page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import BenefitList from './components/BenefitList';
 
 const page = () => {

--- a/apps/user/src/app/(main)/mypage/page.tsx
+++ b/apps/user/src/app/(main)/mypage/page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import ProfileCard from './components/ui/ProfileCard';
 import ProfileInfo from './components/ProfileInfo';
 import ProfileStatistics from './components/ProfileStatistics';

--- a/apps/user/src/app/(no-layout)/components/KakaoLoginBtn.tsx
+++ b/apps/user/src/app/(no-layout)/components/KakaoLoginBtn.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React from 'react';
+
 import { apiHandler } from '@api/apiHandler';
 import { kakaoLogin } from '@/service/user';
 

--- a/apps/user/src/app/(no-layout)/kakaocallback/page.tsx
+++ b/apps/user/src/app/(no-layout)/kakaocallback/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { kakaoLogin } from '@/service/user';
 import { apiHandler } from '@api/apiHandler';

--- a/apps/user/src/app/(no-layout)/signup/components/InputBarcodeNumber.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/InputBarcodeNumber.tsx
@@ -1,0 +1,11 @@
+
+
+const InputBarcodeNumber = () => {
+  return (
+    <div>
+
+    </div>
+  );
+};
+
+export default InputBarcodeNumber;

--- a/apps/user/src/app/(no-layout)/signup/components/InputBarcodeNumber.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/InputBarcodeNumber.tsx
@@ -1,9 +1,54 @@
+'use client'
+import { Input } from "@workspace/ui/components/input";
+import { useState } from "react";
 
 
 const InputBarcodeNumber = () => {
-  return (
-    <div>
+  const [barcodeNumber, setBarcodeNumber] = useState("");
 
+  const handleBarcodeChange = (value: string) => {
+    // 숫자만 추출 음수 입력 방지
+    const numbers = value.replace(/\D/g, "");
+    // 0으로 시작하는 경우도 허용, 빈 값도 허용
+    if (numbers === "" || /^[0-9]+$/.test(numbers)) {
+      setBarcodeNumber(numbers);
+    }
+  };
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-xl font-semibold text-gray-900 leading-tight">
+          멤버십 바코드 번호를
+          <br />
+          입력해주세요
+        </h1>
+        <p className="text-sm text-gray-500 font-medium">기존 멤버십 바코드가 있다면 입력해주세요 (선택사항)</p>
+      </div>
+
+      <div className="space-y-6">
+        <div className="relative">
+          <Input
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            placeholder="바코드 번호 입력 (숫자만)"
+            value={barcodeNumber}
+            onChange={(e) => handleBarcodeChange(e.target.value)}
+            variant="default"
+            className="w-full h-12 text-base font-medium"
+            maxLength={16}
+          />
+        </div>
+
+        <div className="bg-gray-50 rounded-lg p-4">
+          <h3 className="text-sm font-medium text-gray-900 mb-2">안내사항</h3>
+          <ul className="text-xs text-gray-600 space-y-1">
+            <li>• 바코드 번호는 16자리 숫자입니다</li>
+            <li>• 잘못된 번호 입력 시 나중에 수정할 수 있습니다</li>
+            <li>• 입력하지 않아도 서비스 이용이 가능합니다</li>
+          </ul>
+        </div>
+      </div>
     </div>
   );
 };

--- a/apps/user/src/app/(no-layout)/signup/components/InputBirth.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/InputBirth.tsx
@@ -1,9 +1,63 @@
+'use client'
+import { DatePickerPopover } from "@/components/user/DatePickerPopover";
+import { StepProps } from "@/types/profile";
+import { Input } from "@workspace/ui/components/input";
+import { useState } from "react";
 
+const formatDate = (date: Date) => {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
 
-const InputBirth = () => {
+const InputBirth = ({ info, setInfo }: StepProps) => {
+  const [open, setOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(
+    info.birthDate ? new Date(info.birthDate) : undefined
+  );
+  const [month, setMonth] = useState<Date | undefined>(undefined);
+
   return (
-    <div>
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-xl font-semibold text-gray-900 leading-tight">
+          생년월일을
+          <br />
+          입력해주세요
+        </h1>
+        <p className="text-sm text-gray-500 font-medium">연령대별 혜택 추천을 위해 필요해요</p>
+      </div>
 
+      <div className="space-y-4">
+        <div className="relative">
+          <Input
+            variant="calendar"
+            placeholder="YYYY.MM.DD"
+            value={selectedDate ? formatDate(selectedDate) : ''}
+            readOnly
+          />
+          <DatePickerPopover
+            isModal={false}
+            open={open}
+            onOpenChange={setOpen}
+            date={selectedDate}
+            month={month}
+            onMonthChange={setMonth}
+            onSelect={(date) => {
+              setSelectedDate(date);
+              setOpen(false);
+              // info.birthDate에 yyyy-mm-dd 형식으로 저장
+              setInfo({
+                ...info,
+                birthDate: date
+                  ? date.toISOString().slice(0, 10) // 'YYYY-MM-DD'
+                  : '',
+              });
+            }}
+          />
+        </div>
+      </div>
     </div>
   );
 };

--- a/apps/user/src/app/(no-layout)/signup/components/InputBirth.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/InputBirth.tsx
@@ -1,0 +1,11 @@
+
+
+const InputBirth = () => {
+  return (
+    <div>
+
+    </div>
+  );
+};
+
+export default InputBirth;

--- a/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { TOTAL_STEPS } from '@/types/constants';
 import { Button } from '@workspace/ui/components/button';
 import { useRouter } from 'next/navigation';
 import { Dispatch, SetStateAction } from 'react';
@@ -11,7 +12,7 @@ interface NextStepBtnProps {
 const NextStepBtn = ({ currentStep, canProceed, setCurrentStep }: NextStepBtnProps) => {
   const router = useRouter();
   const handleNext = () => {
-    if (currentStep < 5) {
+    if (currentStep < TOTAL_STEPS) {
       setCurrentStep(currentStep + 1)
     } else {
       // completeOnboarding({
@@ -34,7 +35,7 @@ const NextStepBtn = ({ currentStep, canProceed, setCurrentStep }: NextStepBtnPro
         className={`w-full h-12 text-sm font-semibold rounded-lg transition-all ${canProceed() ? "bg-[#41d596] hover:bg-[#14B470] text-white" : "bg-gray-200 text-gray-400 cursor-not-allowed"
           }`}
       >
-        {currentStep === 5 ? "시작하기" : "다음"}
+        {currentStep === TOTAL_STEPS ? "시작하기" : "다음"}
       </Button>
     </div>
   );

--- a/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
@@ -1,0 +1,43 @@
+'use client'
+import { Button } from '@workspace/ui/components/button';
+import { useRouter } from 'next/navigation';
+import { Dispatch, SetStateAction } from 'react';
+
+interface NextStepBtnProps {
+  currentStep: number;
+  canProceed: () => boolean;
+  setCurrentStep: Dispatch<SetStateAction<number>>;
+}
+const NextStepBtn = ({ currentStep, canProceed, setCurrentStep }: NextStepBtnProps) => {
+  const router = useRouter();
+  const handleNext = () => {
+    if (currentStep < 5) {
+      setCurrentStep(currentStep + 1)
+    } else {
+      // completeOnboarding({
+      //   grade: formData.grade,
+      //   birthDate: formData.birthDate,
+      //   gender: formData.gender,
+      //   preferences: { interests: formData.interests },
+      //   barcodeNumber: formData.barcodeNumber,
+      // })
+      // 여기서 비동기 처리 후 routing
+      router.push("/home")
+    }
+  }
+
+  return (
+    <div className="p-5 pt-0">
+      <Button
+        onClick={handleNext}
+        disabled={!canProceed()}
+        className={`w-full h-12 text-sm font-semibold rounded-lg transition-all ${canProceed() ? "bg-[#41d596] hover:bg-[#14B470] text-white" : "bg-gray-200 text-gray-400 cursor-not-allowed"
+          }`}
+      >
+        {currentStep === 5 ? "시작하기" : "다음"}
+      </Button>
+    </div>
+  );
+};
+
+export default NextStepBtn;

--- a/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
@@ -1,5 +1,8 @@
 'use client'
+import { setUserInfo } from '@/service/user';
 import { TOTAL_STEPS } from '@/types/constants';
+import { InfoForm } from '@/types/profile';
+import { apiHandler } from '@api/apiHandler';
 import { Button } from '@workspace/ui/components/button';
 import { useRouter } from 'next/navigation';
 import { Dispatch, SetStateAction } from 'react';
@@ -8,22 +11,26 @@ interface NextStepBtnProps {
   currentStep: number;
   canProceed: () => boolean;
   setCurrentStep: Dispatch<SetStateAction<number>>;
+  info: InfoForm;
 }
-const NextStepBtn = ({ currentStep, canProceed, setCurrentStep }: NextStepBtnProps) => {
+const NextStepBtn = ({ currentStep, canProceed, setCurrentStep, info }: NextStepBtnProps) => {
   const router = useRouter();
-  const handleNext = () => {
+
+  const storeUserInfo = async () => {
+    const { data } = await apiHandler(() => setUserInfo(info));
+    const result = data?.statusCode;
+    return result === 0 ? true : false;
+  }
+
+  const handleNext = async () => {
     if (currentStep < TOTAL_STEPS) {
       setCurrentStep(currentStep + 1)
     } else {
-      // completeOnboarding({
-      //   grade: formData.grade,
-      //   birthDate: formData.birthDate,
-      //   gender: formData.gender,
-      //   preferences: { interests: formData.interests },
-      //   barcodeNumber: formData.barcodeNumber,
-      // })
-      // 여기서 비동기 처리 후 routing
-      router.push("/home")
+      const storeResult = await storeUserInfo();
+      if (storeResult) {
+        router.push("/home")
+      }
+      else alert("정보 저장을 실패했습니다.");
     }
   }
 

--- a/apps/user/src/app/(no-layout)/signup/components/ProgressHeader.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/ProgressHeader.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { TOTAL_STEPS } from '@/types/constants';
 import { ChevronLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Dispatch, Fragment, SetStateAction } from 'react';
@@ -10,7 +11,7 @@ interface ProgressHeaderProps {
 const ProgressHeader = ({ currentStep, setCurrentStep }: ProgressHeaderProps) => {
   const router = useRouter();
   const handleBack = () => {
-    if (currentStep > 1) {
+    if (currentStep > 1 && currentStep <= TOTAL_STEPS) {
       setCurrentStep(currentStep - 1)
     } else {
       router.back()

--- a/apps/user/src/app/(no-layout)/signup/components/ProgressHeader.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/ProgressHeader.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { ChevronLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { Dispatch, Fragment, SetStateAction } from 'react';
+
+interface ProgressHeaderProps {
+  currentStep: number;
+  setCurrentStep: Dispatch<SetStateAction<number>>;
+}
+const ProgressHeader = ({ currentStep, setCurrentStep }: ProgressHeaderProps) => {
+  const router = useRouter();
+  const handleBack = () => {
+    if (currentStep > 1) {
+      setCurrentStep(currentStep - 1)
+    } else {
+      router.back()
+    }
+  }
+
+  return (
+    <Fragment>
+      <div className="flex items-center justify-between p-4 h-14">
+        {currentStep > 1 ? (
+          <button onClick={handleBack} className="p-1">
+            <ChevronLeft className="w-5 h-5" />
+          </button>
+        ) : (
+          <div className="w-7 h-7" />
+        )}
+        <div className="w-7 h-7" />
+      </div>
+
+      {/* 진행 상태 바 */}
+      <div className="px-4 pb-4">
+        <div className="w-full bg-gray-200 rounded-full h-1">
+          <div
+            className="bg-[#41d596] h-1 rounded-full transition-all duration-300"
+            style={{ width: `${(currentStep / 5) * 100}%` }}
+          />
+        </div>
+      </div>
+    </Fragment>
+  );
+};
+
+export default ProgressHeader;

--- a/apps/user/src/app/(no-layout)/signup/components/SelectCategory.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SelectCategory.tsx
@@ -15,7 +15,7 @@ const CATEGORIES = {
 const CATEGORY_KEYS = Object.keys(CATEGORIES).map(Number); // [1,2,3,4,5,6,7,8]
 const SelectCategory = ({ info, setInfo }: StepProps) => {
   // categoryIds를 number[]로 변환 (profile.ts는 그대로 두고 여기서만 처리)
-  const categoryIds: number[] = (info.categoryIds as unknown as number[]) ?? [];
+  const categoryIds: number[] = info.categoryIds;
 
   const toggleInterest = (key: number) => {
     if (categoryIds.includes(key)) {

--- a/apps/user/src/app/(no-layout)/signup/components/SelectCategory.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SelectCategory.tsx
@@ -1,0 +1,11 @@
+
+
+const SelectCategory = () => {
+  return (
+    <div>
+
+    </div>
+  );
+};
+
+export default SelectCategory;

--- a/apps/user/src/app/(no-layout)/signup/components/SelectCategory.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SelectCategory.tsx
@@ -1,9 +1,69 @@
+import { StepProps } from "@/types/profile";
+import { Button } from "@workspace/ui/components/button";
 
+/** 서버에 정수 배열로 넘겨줘야 해서 key:value 쌍으로 카테고리 선언 */
+const CATEGORIES = {
+  1: "액티비티",
+  2: "뷰티/건강",
+  3: "쇼핑",
+  4: "생활/편의",
+  5: "푸드",
+  6: "문화여가",
+  7: "교육",
+  8: "여행/교통"
+} as const;
+const CATEGORY_KEYS = Object.keys(CATEGORIES).map(Number); // [1,2,3,4,5,6,7,8]
+const SelectCategory = ({ info, setInfo }: StepProps) => {
+  // categoryIds를 number[]로 변환 (profile.ts는 그대로 두고 여기서만 처리)
+  const categoryIds: number[] = (info.categoryIds as unknown as number[]) ?? [];
 
-const SelectCategory = () => {
+  const toggleInterest = (key: number) => {
+    if (categoryIds.includes(key)) {
+      setInfo({ ...info, categoryIds: categoryIds.filter((id) => id !== key) });
+    } else if (categoryIds.length < 3) {
+      setInfo({ ...info, categoryIds: [...categoryIds, key] });
+    }
+  };
+
   return (
-    <div>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-xl font-semibold text-gray-900 leading-tight">
+          관심 있는 분야를
+          <br />
+          선택해주세요
+        </h1>
+        <p className="text-sm text-gray-500 font-medium">관심 있는 분야를 선택해주세요</p>
+      </div>
 
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-3">
+          {CATEGORY_KEYS.map((key) => {
+            const isSelected = categoryIds.includes(key);
+            const isDisabled = !isSelected && categoryIds.length >= 3;
+
+            return (
+              <Button
+                key={key}
+                onClick={() => toggleInterest(key)}
+                disabled={isDisabled}
+                variant={isSelected
+                  ? "onb_selected"
+                  : "onb_unselected"
+                }
+              >
+                <span className="text-sm font-semibold">{CATEGORIES[key as keyof typeof CATEGORIES]}</span>
+              </Button>
+            )
+          })}
+        </div>
+
+        {categoryIds.length > 0 && (
+          <div className="text-center">
+            <span className="text-sm text-[#41d596] font-semibold">{categoryIds.length}/3개 선택됨</span>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/user/src/app/(no-layout)/signup/components/SelectGender.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SelectGender.tsx
@@ -1,9 +1,47 @@
+import { StepProps } from "@/types/profile";
 
 
-const SelectGender = () => {
+const SelectGender = ({ info, setInfo }: StepProps) => {
+  const selectToEng = (gender: string) => {
+    return gender === "남성" ? "MALE" : "FEMALE";
+  }
+
   return (
-    <div>
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-xl font-semibold text-gray-900 leading-tight">
+          성별을
+          <br />
+          선택해주세요
+        </h1>
+        <p className="text-sm text-gray-500 font-medium">맞춤 혜택 제공을 위해 필요해요</p>
+      </div>
 
+      <div className="space-y-4">
+        {["남성", "여성"].map((gender) => (
+          <label key={gender} className="flex items-center space-x-3 cursor-pointer">
+            <div className="relative">
+              <input
+                type="radio"
+                name="gender"
+                value={gender}
+                checked={info.gender === gender}
+                onChange={(e) => setInfo({ ...info, gender: selectToEng(e.target.value) })}
+                className="sr-only"
+              />
+              <div
+                className={`w-5 h-5 rounded-full border-2 transition-all ${info.gender === selectToEng(gender) ? "border-[#41d596] bg-[#41d596]" : "border-gray-300"
+                  }`}
+              >
+                {info.gender === gender && (
+                  <div className="w-2 h-2 bg-white rounded-full absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2" />
+                )}
+              </div>
+            </div>
+            <span className="text-sm font-semibold text-gray-900">{gender}</span>
+          </label>
+        ))}
+      </div>
     </div>
   );
 };

--- a/apps/user/src/app/(no-layout)/signup/components/SelectGender.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SelectGender.tsx
@@ -1,0 +1,11 @@
+
+
+const SelectGender = () => {
+  return (
+    <div>
+
+    </div>
+  );
+};
+
+export default SelectGender;

--- a/apps/user/src/app/(no-layout)/signup/components/SelectGender.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SelectGender.tsx
@@ -25,7 +25,7 @@ const SelectGender = ({ info, setInfo }: StepProps) => {
                 type="radio"
                 name="gender"
                 value={gender}
-                checked={info.gender === gender}
+                checked={info.gender === selectToEng(gender)}
                 onChange={(e) => setInfo({ ...info, gender: selectToEng(e.target.value) })}
                 className="sr-only"
               />
@@ -33,7 +33,7 @@ const SelectGender = ({ info, setInfo }: StepProps) => {
                 className={`w-5 h-5 rounded-full border-2 transition-all ${info.gender === selectToEng(gender) ? "border-[#41d596] bg-[#41d596]" : "border-gray-300"
                   }`}
               >
-                {info.gender === gender && (
+                {info.gender === selectToEng(gender) && (
                   <div className="w-2 h-2 bg-white rounded-full absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2" />
                 )}
               </div>

--- a/apps/user/src/app/(no-layout)/signup/components/SelectMembership.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SelectMembership.tsx
@@ -1,9 +1,33 @@
+import { StepProps } from "@/types/profile";
 
+const SelectMembership = ({ info, setInfo }: StepProps) => {
+  const MEMBERSHIP_GRADES = ["VVIP", "VIP", "우수", "일반"];
 
-const SelectMembership = () => {
   return (
-    <div>
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-xl font-semibold text-gray-900 leading-tight">
+          멤버십 등급을
+          <br />
+          선택해주세요
+        </h1>
+        <p className="text-sm text-gray-500 font-medium">현재 멤버십 등급을 선택하세요</p>
+      </div>
 
+      <div className="grid grid-cols-2 gap-3">
+        {MEMBERSHIP_GRADES.map((rank) => (
+          <button
+            key={rank}
+            onClick={() => setInfo({ ...info, rank: rank })}
+            className={`py-3 px-4 rounded-lg transition-all ${info.rank === rank
+              ? "bg-[#41d596]/10 text-[#41d596]"
+              : "bg-gray-100 text-gray-600 hover:bg-[#41d596]/10 hover:text-[#41d596]"
+              }`}
+          >
+            <span className="text-sm font-semibold">{rank}</span>
+          </button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/apps/user/src/app/(no-layout)/signup/components/SelectMembership.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SelectMembership.tsx
@@ -1,0 +1,11 @@
+
+
+const SelectMembership = () => {
+  return (
+    <div>
+
+    </div>
+  );
+};
+
+export default SelectMembership;

--- a/apps/user/src/app/(no-layout)/signup/components/SelectMembership.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SelectMembership.tsx
@@ -1,4 +1,5 @@
 import { StepProps } from "@/types/profile";
+import { Button } from "@workspace/ui/components/button";
 
 const SelectMembership = ({ info, setInfo }: StepProps) => {
   const MEMBERSHIP_GRADES = ["VVIP", "VIP", "우수", "일반"];
@@ -16,16 +17,14 @@ const SelectMembership = ({ info, setInfo }: StepProps) => {
 
       <div className="grid grid-cols-2 gap-3">
         {MEMBERSHIP_GRADES.map((rank) => (
-          <button
+          <Button
             key={rank}
             onClick={() => setInfo({ ...info, rank: rank })}
-            className={`py-3 px-4 rounded-lg transition-all ${info.rank === rank
-              ? "bg-[#41d596]/10 text-[#41d596]"
-              : "bg-gray-100 text-gray-600 hover:bg-[#41d596]/10 hover:text-[#41d596]"
-              }`}
+            className="py-3 px-4 rounded-lg transition-all"
+            variant={info.rank === rank ? "onb_selected" : "onb_unselected"}
           >
             <span className="text-sm font-semibold">{rank}</span>
-          </button>
+          </Button>
         ))}
       </div>
     </div>

--- a/apps/user/src/app/(no-layout)/signup/components/SignupContainer.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SignupContainer.tsx
@@ -1,0 +1,31 @@
+'use client'
+import { useState } from "react";
+import SelectMembership from "./SelectMembership";
+import SelectGender from "./SelectGender";
+import InputBirth from "./InputBirth";
+import SelectCategory from "./SelectCategory";
+import InputBarcodeNumber from "./InputBarcodeNumber";
+import ProgressHeader from "./ProgressHeader";
+
+const stepComponentMap: Record<number, React.ComponentType> = {
+  1: SelectMembership,
+  2: SelectGender,
+  3: InputBirth,
+  4: SelectCategory,
+  5: InputBarcodeNumber,
+};
+
+const SignupContainer = () => {
+  const [currentStep, setCurrentStep] = useState<number>(1);
+
+  const StepComponent = stepComponentMap[currentStep];
+
+  return (
+    <div>
+      <ProgressHeader currentStep={currentStep} setCurrentStep={setCurrentStep} />
+      {StepComponent ? <StepComponent /> : null}
+    </div>
+  );
+};
+
+export default SignupContainer;

--- a/apps/user/src/app/(no-layout)/signup/components/SignupContainer.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SignupContainer.tsx
@@ -6,8 +6,10 @@ import InputBirth from "./InputBirth";
 import SelectCategory from "./SelectCategory";
 import InputBarcodeNumber from "./InputBarcodeNumber";
 import ProgressHeader from "./ProgressHeader";
+import { InfoForm, StepProps } from "@/types/profile";
+import NextStepBtn from "./NextStepBtn";
 
-const stepComponentMap: Record<number, React.ComponentType> = {
+const stepComponentMap: Record<number, React.ComponentType<StepProps>> = {
   1: SelectMembership,
   2: SelectGender,
   3: InputBirth,
@@ -17,13 +19,38 @@ const stepComponentMap: Record<number, React.ComponentType> = {
 
 const SignupContainer = () => {
   const [currentStep, setCurrentStep] = useState<number>(1);
-
+  const [info, setInfo] = useState<InfoForm>({
+    rank: "",
+    gender: "",
+    birthDate: "",
+    categoryIds: [],
+  })
   const StepComponent = stepComponentMap[currentStep];
 
+  const canProceed = () => {
+    switch (currentStep) {
+      case 1:
+        return info.rank !== ""
+      case 2:
+        return info.gender !== ""
+      case 3:
+        return info.birthDate !== ""
+      case 4:
+        return info.categoryIds.length > 0
+      case 5:
+        return true // 바코드는 필수가 아님
+      default:
+        return false
+    }
+  }
+
   return (
-    <div>
+    <div className="min-h-screen bg-white flex flex-col">
       <ProgressHeader currentStep={currentStep} setCurrentStep={setCurrentStep} />
-      {StepComponent ? <StepComponent /> : null}
+      <div className="flex-1 px-5 py-4">
+        {StepComponent ? <StepComponent info={info} setInfo={setInfo} /> : null}
+      </div>
+      <NextStepBtn currentStep={currentStep} setCurrentStep={setCurrentStep} canProceed={canProceed} />
     </div>
   );
 };

--- a/apps/user/src/app/(no-layout)/signup/components/SignupContainer.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SignupContainer.tsx
@@ -50,7 +50,7 @@ const SignupContainer = () => {
       <div className="flex-1 px-5 py-4">
         {StepComponent ? <StepComponent info={info} setInfo={setInfo} /> : null}
       </div>
-      <NextStepBtn currentStep={currentStep} setCurrentStep={setCurrentStep} canProceed={canProceed} />
+      <NextStepBtn currentStep={currentStep} setCurrentStep={setCurrentStep} canProceed={canProceed} info={info} />
     </div>
   );
 };

--- a/apps/user/src/app/(no-layout)/signup/components/TestBtn.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/TestBtn.tsx
@@ -2,7 +2,7 @@
 import { getUserInfo } from '@/service/user';
 import { apiHandler } from '@api/apiHandler';
 
-import React from 'react';
+
 
 const TestBtn = () => {
   const test = async () => {

--- a/apps/user/src/app/(no-layout)/signup/page.tsx
+++ b/apps/user/src/app/(no-layout)/signup/page.tsx
@@ -1,9 +1,9 @@
-import TestBtn from "./components/TestBtn";
+import SignupContainer from "./components/SignupContainer";
 
 export default function SignupPage() {
   return (
     <div>
-      <TestBtn />
+      <SignupContainer />
     </div>
   );
 }

--- a/apps/user/src/components/FavoriteBtn.tsx
+++ b/apps/user/src/components/FavoriteBtn.tsx
@@ -1,6 +1,6 @@
 import { Heart } from 'lucide-react';
 
-import React from 'react';
+
 import classNames from 'classnames';
 
 interface FavoriteBtnProps {

--- a/apps/user/src/components/ui/DynamicCard.tsx
+++ b/apps/user/src/components/ui/DynamicCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+
 
 import { Card, CardContent } from "@workspace/ui/components/card";
 import { Badge } from "@workspace/ui/components/badge";

--- a/apps/user/src/components/ui/SectionHeader.tsx
+++ b/apps/user/src/components/ui/SectionHeader.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@workspace/ui/components/button';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
-import React from 'react';
+
 
 interface SectionHeaderProps {
   title: string;

--- a/apps/user/src/service/user.ts
+++ b/apps/user/src/service/user.ts
@@ -1,4 +1,4 @@
-import { UserRole } from "@/types/profile";
+import { InfoForm, SetUserInfo, UserRole } from "@/types/profile";
 import api from "@api/http-commons";
 
 export const kakaoLogin = async (code: string): Promise<UserRole> => {
@@ -18,3 +18,9 @@ export const getUserInfo = async () => {
   if (!data) throw new Error("유저 데이터가 존재하지 않음");
   return data;
 }
+
+export const setUserInfo = async (params: InfoForm): Promise<SetUserInfo> => {
+  const { data } = await api.put("api/users/userInfo", params);
+  return data;
+}
+

--- a/apps/user/src/types/constants.ts
+++ b/apps/user/src/types/constants.ts
@@ -6,6 +6,9 @@ export const GRADE_COLORS = {
   일반: "#b5b3c2",
 };
 
+/** 사용자 추가 정보 입력 단계 */
+export const TOTAL_STEPS = 5;
+
 export const CATEGORIES = [
   "전체",
   "계절",
@@ -33,3 +36,4 @@ export const periodOptions: periodType[] = [
   { label: "6개월", value: "6months" },
   { label: "1년", value: "1year" },
 ];
+

--- a/apps/user/src/types/profile.ts
+++ b/apps/user/src/types/profile.ts
@@ -1,3 +1,5 @@
+import { Dispatch, SetStateAction } from "react";
+
 export interface UserInfo {
   nickname: string;
   rank: string;
@@ -14,3 +16,15 @@ export interface UserStatistics {
 export interface UserRole {
   role: string | null;
 }
+
+export interface InfoForm {
+  rank: string;
+  gender: string;
+  birthDate: string;
+  categoryIds: number[];
+}
+
+export interface StepProps {
+  info: InfoForm;
+  setInfo: Dispatch<SetStateAction<InfoForm>>;
+};

--- a/apps/user/src/types/profile.ts
+++ b/apps/user/src/types/profile.ts
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction } from "react";
+import { responseStatus } from "./api";
 
 export interface UserInfo {
   nickname: string;
@@ -28,3 +29,7 @@ export interface StepProps {
   info: InfoForm;
   setInfo: Dispatch<SetStateAction<InfoForm>>;
 };
+
+export interface SetUserInfo extends responseStatus {
+  data: InfoForm;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,12 @@ importers:
       lucide-react:
         specifier: ^0.475.0
         version: 0.475.0(react@19.1.0)
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      zustand:
+        specifier: ^5.0.6
+        version: 5.0.6(@types/react@19.1.8)(react@19.1.0)
     devDependencies:
       '@types/navermaps':
         specifier: ^3.9.1
@@ -3890,7 +3896,7 @@ packages:
   socks@2.8.5:
     resolution: {integrity: sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-    
+
   sonner@2.0.6:
     resolution: {integrity: sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==}
     peerDependencies:
@@ -4301,6 +4307,12 @@ packages:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -4476,6 +4488,24 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zustand@5.0.6:
+    resolution: {integrity: sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -5641,13 +5671,13 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
-  '@types/geojson@7946.0.16': {}
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/glob@7.2.0':
     dependencies:
@@ -5668,6 +5698,10 @@ snapshots:
   '@types/minimatch@6.0.0':
     dependencies:
       minimatch: 9.0.5
+
+  '@types/navermaps@3.9.1':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/node@20.19.6':
     dependencies:
@@ -8666,6 +8700,15 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
+  vaul@1.1.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
   vite-node@3.2.4(@types/node@20.19.6)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1):
     dependencies:
       cac: 6.7.14
@@ -8863,3 +8906,8 @@ snapshots:
   yocto-queue@1.2.1: {}
 
   zod@3.25.76: {}
+
+  zustand@5.0.6(@types/react@19.1.8)(react@19.1.0):
+    optionalDependencies:
+      '@types/react': 19.1.8
+      react: 19.1.0


### PR DESCRIPTION
## #️⃣연관된 이슈

> #24 

## 📝작업 내용

- 사용자 정보 입력, 수정 응답 type 정의
- 사용자 정보 입력, 수정 서비스 구현
- 사용자 최초 정보 입력 시 마지막 단계에서 저장 요청, 응답 검증 수행

## 📷스크린샷 (선택)

<img width="1811" height="65" alt="image" src="https://github.com/user-attachments/assets/4e84ccba-d87e-498c-b2ea-8554bb361ca4" />

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a multi-step signup process with components for selecting membership grade, gender, birth date, interest categories, and barcode number.
  * Added visual progress tracking and navigation for the signup flow.
  * Enabled saving of user profile information during signup.

* **Enhancements**
  * Development server for the admin app now runs on port 3001.
  * User app development server now supports experimental HTTPS.
  * Improved type safety and structure for user profile and signup-related data.

* **Refactor**
  * Removed unnecessary React imports across multiple components for cleaner code.
  * Updated the signup page to use the new multi-step signup container.

* **Chores**
  * Removed obsolete development script from the Storybook app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->