### PR TITLE
[FEAT] UBLE-43 카테고리 타입, API, store, UI 연동 및 카테고리 선택 UI 개선

### DIFF
--- a/apps/user/src/app/(main)/map/components/CategorySection.tsx
+++ b/apps/user/src/app/(main)/map/components/CategorySection.tsx
@@ -1,12 +1,13 @@
 "use client";
 import CategoryBar from "@/components/common/CategoryBar";
-import { useMapStore } from "@/store/useMapStore";
+import { Category } from "@/types/category";
+interface CategorySectionProps {
+  selectedCategory: Category;
+  onSelectCategory: (cat: Category) => void;
+}
 
-const CategorySection = () => {
-  const selectedCategory = useMapStore((s) => s.selectedCategory);
-  const setSelectedCategory = useMapStore((s) => s.setSelectedCategory);
-
-  return <CategoryBar selectedCategory={selectedCategory} onSelectCategory={setSelectedCategory} />;
+const CategorySection = ({ selectedCategory, onSelectCategory }: CategorySectionProps) => {
+  return <CategoryBar selectedCategory={selectedCategory} onSelectCategory={onSelectCategory} />;
 };
 
 export default CategorySection;

--- a/apps/user/src/components/common/CategoryBar.tsx
+++ b/apps/user/src/components/common/CategoryBar.tsx
@@ -1,26 +1,30 @@
 "use client";
 
 import { Button } from "@workspace/ui/components/button";
-import { CATEGORIES, Category } from "@/types/constants";
+import { Category } from "@/types/category";
 import { memo } from "react";
+import { useCategoryStore } from "@/store/useCategoryStore";
 
 interface CategoryBarProps {
   selectedCategory: Category;
-  onSelectCategory: (cat: Category) => void;
+  onSelectCategory: (category: Category) => void;
 }
 
 const CategoryBar = ({ selectedCategory, onSelectCategory }: CategoryBarProps) => {
+  const { categories } = useCategoryStore();
+
   return (
     <nav className="scrollbar-hide absolute left-4 right-4 top-16 z-10 flex gap-2 overflow-x-auto whitespace-nowrap py-3">
-      {/* TODO:  추후 백엔드에서 받아온 CATEGORIES로 사용 */}
-      {CATEGORIES.map((cat) => (
+      {categories.map((cat) => (
         <Button
-          key={cat}
-          variant={selectedCategory === cat ? "filter_select" : "filter_unselect"}
+          key={cat.categoryId}
+          variant={
+            selectedCategory.categoryId === cat.categoryId ? "filter_select" : "filter_unselect"
+          }
           size="sm"
           onClick={() => onSelectCategory(cat)}
         >
-          {cat}
+          {cat.categoryName}
         </Button>
       ))}
     </nav>

--- a/apps/user/src/service/category.ts
+++ b/apps/user/src/service/category.ts
@@ -1,0 +1,5 @@
+import api from "@api/http-commons";
+import { apiHandler } from "@api/apiHandler";
+import { CategoryListResponse } from "@/types/category";
+
+export const getCategories = () => apiHandler<CategoryListResponse>(() => api.get("/api/category"));

--- a/apps/user/src/store/useCategoryStore.ts
+++ b/apps/user/src/store/useCategoryStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import { Category } from "@/types/category";
+
+interface CategoryState {
+  categories: Category[];
+  setCategories: (categories: Category[]) => void;
+}
+
+export const useCategoryStore = create<CategoryState>((set) => ({
+  categories: [],
+  setCategories: (categories) => set({ categories }),
+}));

--- a/apps/user/src/types/category.ts
+++ b/apps/user/src/types/category.ts
@@ -1,0 +1,20 @@
+import { responseStatus } from "./api";
+
+export interface Category {
+  /** 카테고리 ID */
+  categoryId: number | "SEASON" | "VIP" | "LOCAL";
+  /** 카테고리 이름 */
+  categoryName: string;
+}
+
+/**
+ * 카테고리 전체 조회 API
+ */
+export interface CategoryListResponse extends responseStatus {
+  data: {
+    data: {
+      /** 카테고리 목록 데이터 */
+      categoryList: Category[];
+    };
+  };
+}

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -37,6 +37,8 @@ const buttonVariants = cva(
 
         circle_outline:
           "rounded-full border border-gray-300 bg-white shadow-lg hover:bg-gray-50 hover:text-gray-900",
+        ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        none: "",
       },
       size: {
         default: "h-10 px-4 py-2 has-[>svg]:px-3",


### PR DESCRIPTION
## #️⃣연관된 이슈

#27 

## 📝작업 내용

- 카테고리 타입 및 카테고리 전체 조회 응답 타입 추가 (`Category`, `CategoryListResponse`)
- zustand 기반 카테고리 리스트 관리 store(`useCategoryStore`) 추가
- 카테고리 목록 조회 API 서비스 함수(`getCategories`) 추가
- category store에서 카테고리 목록을 받아와 CategoryBar에서 렌더링하도록 연동
- 버튼 ghost variant 추가

## 📷스크린샷 (선택)


## 💬리뷰 요구사항(선택)
현재 map 페이지 마운트시 카테고리 목록 조회 API 함수 실행 및 store에 저장하도록 했는데, signup과 home에서의 사용을 위해 추후 useCategoryStore에 카테고리 존재 여부 조건문 추가하여 로직 개선할 예정입니다.