### PR TITLE
[FEAT] UBLE-51 사용자 정보 전역 관리

### DIFF
--- a/apps/user/src/app/(main)/layout.tsx
+++ b/apps/user/src/app/(main)/layout.tsx
@@ -3,6 +3,7 @@ import Footer from "../../components/common/Footer";
 import Header from "../../components/common/Header";
 
 import { Providers } from "@/components/providers";
+import HydrateData from "@/components/HydrateData";
 
 export default function RootLayout({
   children,
@@ -13,6 +14,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body>
         <Providers>
+          <HydrateData />
           <Header />
           <main style={{ paddingBottom: "72px" }}>{children}</main>
           <Footer />

--- a/apps/user/src/components/HydrateData.tsx
+++ b/apps/user/src/components/HydrateData.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { useEffect } from "react";
+import useUserStore from "@/store/useUserStore";
+import { getUserInfo } from "@/service/user";
+import { apiHandler } from "@api/apiHandler";
+
+/** 사용자 정보, 카테고리를 가져와서 store에 저장하기 위한 컴포넌트 */
+const HydrateData = () => {
+  const { setUser, user } = useUserStore();
+  useEffect(() => {
+    (async () => {
+      try {
+        const { data } = await apiHandler(() => getUserInfo());
+        setUser(data.data);
+      } catch (e) {
+        // alert("유저 정보를 불러오지 못했습니다. 다시 로그인해 주세요");
+      }
+    })();
+  }, [setUser]);
+
+  return null;
+};
+
+export default HydrateData;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #48 

## 📝작업 내용

사용자가 메인 콘텐츠에 접속할 시 서버로부터 사용자 정보를 가져온다.

타 컴포넌트가 CSR이 되지 않도록 구현하였다.

## 📷스크린샷 (선택)


## 💬리뷰 요구사항(선택)

카테고리를 불러오는 로직도 HydrateData 컴포넌트에서 수행하면 될 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 정보를 자동으로 불러와 전역 사용자 상태를 초기화하는 기능이 추가되었습니다.  
  * 이 기능은 앱 실행 시 자동으로 동작하며, 별도의 화면 변화 없이 사용자 정보를 최신 상태로 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->