### PR TITLE
[FEAT] UBLE-56 즐겨찾기 마크업 및 조회 API 연동

### DIFF
--- a/apps/user/src/app/(main)/favorite/components/FavoriteBrandSection.tsx
+++ b/apps/user/src/app/(main)/favorite/components/FavoriteBrandSection.tsx
@@ -21,7 +21,7 @@ export default function FavoriteBrandSection() {
   const { data, fetchNextPage, hasNextPage, isLoading, isError, error } = useInfiniteQuery({
     queryKey,
     queryFn: ({ pageParam }) =>
-      fetchFavorites({ ...params, lastBookmarkId: pageParam ? String(pageParam) : undefined }),
+      fetchFavorites({ ...params, lastBookmarkId: pageParam ? pageParam : undefined }),
     getNextPageParam: (lastPage: BrandListData) =>
       lastPage.hasNext ? lastPage.lastCursorId : undefined,
     staleTime: 1000 * 60 * 5,

--- a/apps/user/src/app/(main)/favorite/components/FavoriteBrandSection.tsx
+++ b/apps/user/src/app/(main)/favorite/components/FavoriteBrandSection.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { BrandContent, BrandListData } from "@/types/brand";
+import EmptyState from "@/app/(main)/home/components/ui/EmptyState";
+import DynamicCard from "@/components/ui/DynamicCard";
+import useInfiniteScroll from "@/hooks/useInfiniteScroll";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchFavorites, FetchFavoritesParams } from "@/service/favorites";
+
+export default function FavoriteBrandSection() {
+  // 즐겨찾기 데이터 받아오기
+  const params = useMemo<FetchFavoritesParams>(
+    () => ({
+      size: 20,
+    }),
+    []
+  );
+  const queryKey = ["favoriteBrands", params];
+  const { data, fetchNextPage, hasNextPage, isLoading, isError, error } = useInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam }) =>
+      fetchFavorites({ ...params, lastBookmarkId: pageParam ? String(pageParam) : undefined }),
+    getNextPageParam: (lastPage: BrandListData) =>
+      lastPage.hasNext ? lastPage.lastCursorId : undefined,
+    staleTime: 1000 * 60 * 5,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    initialPageParam: undefined,
+  });
+
+  const loadMoreRef = useInfiniteScroll({
+    hasNextPage,
+    fetchNextPage,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-48 items-center justify-center">
+        {/* <CircleLoader color="#F89520" /> */}
+        로딩중...
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <div>에러가 발생했습니다: {error.message}</div>;
+  }
+
+  const favoriteBrands = data?.pages.flatMap((page) => page.content) || [];
+  if (!favoriteBrands) return <div>로딩중...</div>;
+
+  console.log(favoriteBrands);
+  if (favoriteBrands.length === 0) {
+    return (
+      <div className="py-12 text-center">
+        <div className="mb-2 text-gray-400"></div>
+        <p className="text-gray-500">즐겨찾기한 제휴처가 없습니다.</p>
+      </div>
+    );
+  }
+  return (
+    <div>
+      {favoriteBrands.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <>
+          <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {favoriteBrands.map((brand: BrandContent) => (
+              <DynamicCard key={brand.brandId} data={brand} variant="horizontal" />
+            ))}
+          </div>
+          <div ref={loadMoreRef} className="h-1" />
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/user/src/app/(main)/favorite/components/FavoriteBrandSection.tsx
+++ b/apps/user/src/app/(main)/favorite/components/FavoriteBrandSection.tsx
@@ -51,7 +51,6 @@ export default function FavoriteBrandSection() {
   const favoriteBrands = data?.pages.flatMap((page) => page.content) || [];
   if (!favoriteBrands) return <div>로딩중...</div>;
 
-  console.log(favoriteBrands);
   if (favoriteBrands.length === 0) {
     return (
       <div className="py-12 text-center">
@@ -62,18 +61,12 @@ export default function FavoriteBrandSection() {
   }
   return (
     <div>
-      {favoriteBrands.length === 0 ? (
-        <EmptyState />
-      ) : (
-        <>
-          <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {favoriteBrands.map((brand: BrandContent) => (
-              <DynamicCard key={brand.brandId} data={brand} variant="horizontal" />
-            ))}
-          </div>
-          <div ref={loadMoreRef} className="h-1" />
-        </>
-      )}
+      <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {favoriteBrands.map((brand: BrandContent) => (
+          <DynamicCard key={brand.brandId} data={brand} variant="horizontal" />
+        ))}
+      </div>
+      <div ref={loadMoreRef} className="h-1" />
     </div>
   );
 }

--- a/apps/user/src/app/(main)/favorite/components/FavoriteSectionProvider.tsx
+++ b/apps/user/src/app/(main)/favorite/components/FavoriteSectionProvider.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import FavoriteBrandSection from "./FavoriteBrandSection";
+
+const queryClient = new QueryClient();
+
+const FavoriteSectionProvider = () => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <FavoriteBrandSection />
+    </QueryClientProvider>
+  );
+};
+
+export default FavoriteSectionProvider;

--- a/apps/user/src/app/(main)/favorite/page.tsx
+++ b/apps/user/src/app/(main)/favorite/page.tsx
@@ -1,0 +1,13 @@
+import FavoriteSectionProvider from "@/app/(main)/favorite/components/FavoriteSectionProvider";
+
+export default function FavoritePage() {
+  return (
+    <section>
+      {/* <hr className="border-gray-300" /> */}
+      <div className="space-y-4 p-4">
+        <h3 className="text-lg font-semibold">즐겨찾기</h3>
+        {/* <FavoriteSectionProvider /> */}
+      </div>
+    </section>
+  );
+}

--- a/apps/user/src/app/(main)/favorite/page.tsx
+++ b/apps/user/src/app/(main)/favorite/page.tsx
@@ -6,7 +6,7 @@ export default function FavoritePage() {
       {/* <hr className="border-gray-300" /> */}
       <div className="space-y-4 p-4">
         <h3 className="text-lg font-semibold">즐겨찾기</h3>
-        {/* <FavoriteSectionProvider /> */}
+        <FavoriteSectionProvider />
       </div>
     </section>
   );

--- a/apps/user/src/app/(main)/home/components/ui/MembershipGrade.tsx
+++ b/apps/user/src/app/(main)/home/components/ui/MembershipGrade.tsx
@@ -35,7 +35,8 @@ const MembershipGrade = ({ rank, isVIPcock }: MembershipGradeProps) => {
   if (isVIPcock && rank === "VIP") {
     grades.push("VIP콕");
   } else {
-    grades.push(...RANK_MAP[rank]);
+    // TODO: 수정된 즐겨찾기 api 연결시 || [] 삭제
+    grades.push(...(RANK_MAP[rank] || []));
     if (isVIPcock) {
       grades.push("VIP콕");
     }

--- a/apps/user/src/components/ui/DynamicCard.tsx
+++ b/apps/user/src/components/ui/DynamicCard.tsx
@@ -1,11 +1,10 @@
-
-
 import { Card, CardContent } from "@workspace/ui/components/card";
 import MembershipGrade from "../../app/(main)/home/components/ui/MembershipGrade";
 import { BrandContent } from "@/types/brand";
 import classNames from "classnames";
 import FavoriteBtn from "../FavoriteBtn";
 import { memo } from "react";
+import Image from "next/image";
 
 type Variant = "vertical" | "horizontal";
 interface DynamicCardProps {
@@ -19,7 +18,7 @@ const DynamicCard = ({ data, variant = "vertical" }: DynamicCardProps) => {
     <Card
       // onClick={onClick}
       className={classNames(
-        "cursor-pointer border-gray-200 bg-white transition-all duration-200 hover:border-[#41d596] hover:shadow-lg",
+        "cursor-pointer border-gray-200 bg-white object-fill transition-all duration-200 hover:border-[#41d596] hover:shadow-lg",
         {
           // 세로형: 고정 너비 & 세로 레이아웃
           "w-64 flex-shrink-0": variant === "vertical",
@@ -33,8 +32,10 @@ const DynamicCard = ({ data, variant = "vertical" }: DynamicCardProps) => {
           // --- Vertical Layout ---
           <>
             <div className="relative">
-              <img
+              <Image
                 src={imgUrl || "/placeholder.png"}
+                width={32}
+                height={32}
                 alt={name}
                 className="h-32 w-full rounded-t-lg object-cover"
               />
@@ -56,10 +57,12 @@ const DynamicCard = ({ data, variant = "vertical" }: DynamicCardProps) => {
         ) : (
           // --- Horizontal Layout ---
           <div className="flex items-center space-x-4">
-            <img
+            <Image
               src={imgUrl || "/placeholder.png"}
+              width={32}
+              height={32}
               alt={name}
-              className="h-16 w-16 flex-shrink-0 rounded-lg object-cover"
+              className="h-16 w-16 flex-shrink-0 rounded-lg object-fill"
             />
             <div className="min-w-0 flex-1">
               <div className="mb-2 flex items-start justify-between">

--- a/apps/user/src/service/favorites.ts
+++ b/apps/user/src/service/favorites.ts
@@ -7,7 +7,6 @@ export interface FetchFavoritesParams {
 }
 
 export const fetchFavorites = async (params: FetchFavoritesParams): Promise<BrandListData> => {
-  const res = await api.get<BrandListResponse>("api/bookmarks", { params });
-  console.log(res);
-  return res.data.data;
+  const { data } = await api.get<BrandListResponse>("api/bookmarks", { params });
+  return data.data;
 };

--- a/apps/user/src/service/favorites.ts
+++ b/apps/user/src/service/favorites.ts
@@ -1,0 +1,13 @@
+import { BrandListData, BrandListResponse } from "@/types/brand";
+import api from "@api/http-commons";
+
+export interface FetchFavoritesParams {
+  lastBookmarkId?: string;
+  size?: number;
+}
+
+export const fetchFavorites = async (params: FetchFavoritesParams): Promise<BrandListData> => {
+  const res = await api.get<BrandListResponse>("api/bookmarks", { params });
+  console.log(res);
+  return res.data.data;
+};

--- a/apps/user/src/service/favorites.ts
+++ b/apps/user/src/service/favorites.ts
@@ -2,7 +2,7 @@ import { BrandListData, BrandListResponse } from "@/types/brand";
 import api from "@api/http-commons";
 
 export interface FetchFavoritesParams {
-  lastBookmarkId?: string;
+  lastBookmarkId?: number;
   size?: number;
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#56 


## 📝작업 내용

**즐겨찾기**
- 즐겨찾기 페이지 마크업
- 즐겨찾기 전체 조회 api 서비스함수 구현
- api 연동

** **
`DynamicCard.tsx` 내의 img -> next/image 사용으로 변경.

## 📷스크린샷 (선택)
<img width="357" height="788" alt="스크린샷 2025-07-21 오후 4 56 57" src="https://github.com/user-attachments/assets/01f3f847-11b2-4581-882c-ab55d7f2d62e" />


## 💬리뷰 요구사항(선택)

즐겨찾기 api 응답 형식이 제휴처 브랜드 전체 리스트 조회 api 형식과 동일하게 수정될 **예정** 으로, 현재 응답 형식과 달라집니다. 그에 맞춰 미리 형식을 맞추어 임시로 화면 로드를 위해 membershipgrade에 일부 수정 진행했습니다. 화면 또한 수정 이후 정상적으로 보일 것입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 즐겨찾기 브랜드 목록을 무한 스크롤로 확인할 수 있는 즐겨찾기 페이지가 추가되었습니다.
  * 즐겨찾기 브랜드 목록이 없을 경우 안내 메시지가 표시됩니다.

* **개선 사항**
  * 즐겨찾기 목록의 이미지를 최적화된 이미지 컴포넌트로 렌더링하여 성능이 향상되었습니다.
  * 등급 정보 표시 시 예외 상황에 대한 처리가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->