### PR TITLE
[FEAT] UBLE-57 제휴처 상세 페이지 마크업

### DIFF
--- a/apps/user/src/app/(main)/home/components/EntireSection.tsx
+++ b/apps/user/src/app/(main)/home/components/EntireSection.tsx
@@ -14,11 +14,13 @@ import LoadingState from "./ui/LoadingState";
 import ErrorState from "./ui/ErrorState";
 import EmptyState from "./ui/EmptyState";
 import { ALL_CATEGORY } from "@/types/constants";
+import { useRouter } from "next/navigation";
 
 const PAGE_SIZE = 8;
 
 export default function EntireSection() {
   const [categorys, setCategorys] = useState<Category>(ALL_CATEGORY);
+  const router = useRouter();
 
   const params = useMemo<FetchBrandsParams>(
     () => ({
@@ -76,7 +78,7 @@ export default function EntireSection() {
                   {data.pages
                     .flatMap((page) => page.content)
                     .map((brand: BrandContent) => (
-                      <DynamicCard key={brand.brandId} data={brand} variant="horizontal" />
+                      <DynamicCard key={brand.brandId} data={brand} variant="horizontal" onClick={() => router.push(`/partnerships/${brand.brandId}`)} />
                     ))}
                 </div>
                 {/* 이 div가 보일 때마다 다음 페이지를 불러옵니다 */}

--- a/apps/user/src/app/(main)/home/components/PersonalSection.tsx
+++ b/apps/user/src/app/(main)/home/components/PersonalSection.tsx
@@ -13,7 +13,7 @@ const PersonalSection = () => {
     imgUrl: "",
     isVIPcock: true,
     minRank: "NONE",
-    bookmarked: false,
+    isBookmarked: false,
   };
 
   const nickname = useUserStore((state) => state.user.nickname);

--- a/apps/user/src/app/(main)/partnerships/[id]/components/PartnershipBenefitList.tsx
+++ b/apps/user/src/app/(main)/partnerships/[id]/components/PartnershipBenefitList.tsx
@@ -10,7 +10,7 @@ const PartnershipBenefitList = (data: BrandDetailData) => {
       <div className="space-y-6">
         {benefits.map((benefit, idx) => (
           <div
-            key={idx}
+            key={benefit.benefitId}
             className="rounded-xl border border-gray-200 bg-white shadow-sm p-5 space-y-3"
           >
             {/* 등급 뱃지와 혜택명 한 줄에 */}

--- a/apps/user/src/app/(main)/partnerships/[id]/components/PartnershipBenefitList.tsx
+++ b/apps/user/src/app/(main)/partnerships/[id]/components/PartnershipBenefitList.tsx
@@ -1,0 +1,50 @@
+import MembershipGrade from "@/app/(main)/home/components/ui/MembershipGrade";
+import { BrandDetailData } from "@/types/brand";
+
+const PartnershipBenefitList = (data: BrandDetailData) => {
+  const { benefits } = data;
+
+  return (
+    <div className="space-y-4 pt-4">
+      <h1 className="font-bold text-xl">혜택 내용</h1>
+      <div className="space-y-6">
+        {benefits.map((benefit, idx) => (
+          <div
+            key={idx}
+            className="rounded-xl border border-gray-200 bg-white shadow-sm p-5 space-y-3"
+          >
+            {/* 등급 뱃지와 혜택명 한 줄에 */}
+            <div className="flex items-center space-x-2">
+              <MembershipGrade rank={benefit.minRank} isVIPcock={benefit.type === "VIP"} />
+            </div>
+            {/* 혜택 설명 */}
+            {benefit.content.split('\n').map((item, idx) => (
+              <div key={idx} className={idx === 0 ? "text-lg font-semibold text-gray-900" : "text-sm text-gray-700"}>
+                {item}
+              </div>
+            ))}
+            {/* 이용방법 - 토글 UI */}
+            <details className="bg-gray-50 rounded-lg p-3">
+              <summary className="flex items-center justify-between text-sm font-medium mb-1 text-gray-900 cursor-pointer list-none">
+                이용방법 및 유의사항
+                {/* 화살표는 CSS로 바꿀 수도 있고, 간단히 summary 뒤에 텍스트로 표시해도 됨 */}
+                <span className="ml-2 text-xs">▼</span>
+              </summary>
+              <ul className="text-xs text-gray-600 space-y-1 mt-2">
+                {benefit.manual.split('\n').map((item, j) => (
+                  <li key={j}>{item}</li>
+                ))}
+              </ul>
+            </details>
+            {/* 이용 제한 */}
+            <div className="pt-2">
+              <p className="text-xs text-gray-500">이용 제한: {benefit.provisionCount}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PartnershipBenefitList;

--- a/apps/user/src/app/(main)/partnerships/[id]/components/PartnershipContainer.tsx
+++ b/apps/user/src/app/(main)/partnerships/[id]/components/PartnershipContainer.tsx
@@ -1,0 +1,48 @@
+import { BrandContent, BrandDetailData } from "@/types/brand";
+import PartnershipHeader from "./PartnershipHeader";
+import FavoriteBtn from "@/components/FavoriteBtn";
+import PartnershipBenefitList from "./PartnershipBenefitList";
+
+const PartnershipContainer = () => {
+  const data: BrandDetailData = {
+    "brandId": 60,
+    "name": "배스킨라빈스",
+    "csrNumber": "배스킨라빈스 080-555-3131(유료)",
+    "description": "행복을 전하는 프리미엄 아이스크림, 배스킨라빈스",
+    "imgUrl": "https://uble-storage.s3.ap-northeast-2.amazonaws.com/logo/logo/BASKIN_ROBBINS.png",
+    "season": "ETC",
+    "categoryName": "카페",
+    "isBookmarked": true,
+    "bookmarkId": 10,
+    "isVIPcock": true,
+    "benefits": [
+      {
+        "benefitId": 89,
+        "type": "NORMAL",
+        "minRank": "NORMAL",
+        "content": "패밀리 사이즈(5가지 맛) 4천원 할인",
+        "manual": "- U+ 멤버십앱 메인 화면 우측 상단 검색(돋보기 모양) 클릭 > 배스킨라빈스 검색 > 제휴사 클릭 후  '다운로드' 클릭 > U+멤버십 앱 메인 화면 우측 상단 '마이' 클릭 > 내 쿠폰함 > 쿠폰 내 이용방법 및 유의사항 참고\n*꼭 확인하세요\n- 배스킨라빈스 매장에서 구매 시 사용 가능하며, 플레이버 선택 가능합니다.\n- 패밀리사이즈 포장 가능합니다.\n- 1인 1매 사용 가능합니다.\n- 다른 행사나 쿠폰, 제휴할인은 중복 사용이 불가합니다.\n- 모바일 교환권 사용 가능하며, 타 사에서 구매하신 할인된 모바일 교환권으로는 구매가 불가 합니다.\n- 캡쳐 이미지, 출력물 등으로 쿠폰 사용은 불가합니다.\n- 일부 매장에서는 사용이 제한될 수 있습니다. (사용 가능 매장, 배스킨라빈스 홈페이지 참조)\n- 결제 금액의 0.1% 해피포인트 적립 가능합니다.\n- 쿠폰은 발급 받은 달 말일까지 사용 가능하며, 기간 연장은 불가합니다(예시: 1월 30일 발급 시 1월 31일까지 사용 가능)",
+        "provisionCount": "월 1회"
+      },
+      {
+        "benefitId": 60,
+        "type": "VIP",
+        "minRank": "NONE",
+        "content": "싱글레귤러 1개 무료 교환",
+        "manual": "U+ 멤버십앱 메인 화면 우측 하단 ≡(전체) 클릭 >  VIP콕 > 배스킨라빈스 > 상단 '쿠폰 받기' 클릭 > U+멤버십 앱 메인 화면 우측 상단 '마이' 클릭 > 내 쿠폰함 > 쿠폰 내 이용방법 및 유의사항 참고\n*꼭 확인하세요\n- 배스킨라빈스 매장에서 구매 시 사용 가능하며, 플레이버 선택 가능합니다.\n- 1인 1매 사용 가능합니다.\n- 다른 행사나 쿠폰, 제휴할인은 중복 사용이 불가합니다.\n- 싱글레귤러는 포장 불가 합니다.\n- 캡쳐 이미지, 출력물 등으로 쿠폰 사용은 불가합니다.\n- 일부 매장에서는 사용이 제한될 수 있습니다. (사용 가능 매장, 배스킨라빈스 홈페이지 참조)\n- 쿠폰은 발급 받은 달 말일까지 사용 가능하며, 기간 연장은 불가합니다(예시: 1월 30일 발급 시 1월 31일까지 사용 가능)",
+        "provisionCount": "월 1회"
+      }
+    ]
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="p-4 space-y-4">
+        <PartnershipHeader {...data} />
+        <PartnershipBenefitList {...data} />
+      </div>
+    </div>
+  );
+};
+
+export default PartnershipContainer;

--- a/apps/user/src/app/(main)/partnerships/[id]/components/PartnershipHeader.tsx
+++ b/apps/user/src/app/(main)/partnerships/[id]/components/PartnershipHeader.tsx
@@ -1,0 +1,34 @@
+import FavoriteBtn from "@/components/FavoriteBtn";
+import { BrandDetailData } from "@/types/brand";
+import { Badge } from "@workspace/ui/components/badge";
+
+const PartnershipHeader = (props: BrandDetailData) => {
+  const { imgUrl, name, categoryName, description, brandId, isBookmarked, csrNumber } = props;
+  return (
+    <div className="flex items-start justify-between mb-4">
+      <div className="flex flex-col items-start space-y-4">
+        <img
+          src={imgUrl || "/placeholder.png"}
+          alt={name}
+          className="w-24 h-24 rounded object-cover flex-shrink-0"
+        />
+        <div className="space-y-1 w-full">
+          <Badge variant="default">{categoryName}</Badge>
+          <h1 className="text-2xl font-bold">{name}</h1>
+          <div className="flex items-center justify-between w-full">
+            <p className="text-gray-600 flex-1">{description}</p>
+          </div>
+          <p className="text-gray-600 flex-1">{csrNumber}</p>
+
+        </div>
+      </div>
+      <div className="flex space-x-2">
+        <div className="p-0 bg-transparent border-none cursor-pointer">
+          <FavoriteBtn brandId={brandId} bookmarked={isBookmarked} variant="default" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PartnershipHeader;

--- a/apps/user/src/app/(main)/partnerships/[id]/page.tsx
+++ b/apps/user/src/app/(main)/partnerships/[id]/page.tsx
@@ -1,0 +1,11 @@
+import PartnershipContainer from "./components/PartnershipContainer";
+
+const page = () => {
+  return (
+    <div>
+      <PartnershipContainer />
+    </div>
+  );
+};
+
+export default page;

--- a/apps/user/src/components/FavoriteBtn.tsx
+++ b/apps/user/src/components/FavoriteBtn.tsx
@@ -15,7 +15,7 @@ const FavoriteBtn = ({ brandId, bookmarked, variant }: FavoriteBtnProps) => {
       <Heart
         className={classNames(
           variant === 'vertical' ? 'w-4 h-4' : 'w-5 h-5',
-          bookmarked ? 'text-[#FD7563]' : 'text-gray-400'
+          bookmarked ? 'text-[#FD7563]' : 'text-gray-400 hover:text-gray-600'
         )}
         fill={bookmarked ? '#FD7563' : 'none'}
       />

--- a/apps/user/src/components/ui/DynamicCard.tsx
+++ b/apps/user/src/components/ui/DynamicCard.tsx
@@ -11,13 +11,14 @@ type Variant = "vertical" | "horizontal";
 interface DynamicCardProps {
   data: BrandContent;
   variant?: Variant;
+  onClick?: () => void;
 }
-const DynamicCard = ({ data, variant = "vertical" }: DynamicCardProps) => {
-  const { brandId, name, category, description, imgUrl, isVIPcock, minRank, bookmarked } = data;
+const DynamicCard = ({ data, variant = "vertical", onClick }: DynamicCardProps) => {
+  const { brandId, name, category, description, imgUrl, isVIPcock, minRank, isBookmarked } = data;
 
   return (
     <Card
-      // onClick={onClick}
+      onClick={onClick}
       className={classNames(
         "cursor-pointer border-gray-200 bg-white transition-all duration-200 hover:border-[#41d596] hover:shadow-lg",
         {
@@ -44,7 +45,7 @@ const DynamicCard = ({ data, variant = "vertical" }: DynamicCardProps) => {
                 <span className="rounded bg-gray-100 px-2 py-1 text-xs font-semibold text-gray-500">
                   {category}
                 </span>
-                <FavoriteBtn brandId={brandId} bookmarked={bookmarked} variant={variant} />
+                <FavoriteBtn brandId={brandId} bookmarked={isBookmarked} variant={variant} />
               </div>
               <h3 className="line-clamp-1 text-sm font-semibold text-gray-900">{name}</h3>
               <h5 className="line-clamp-1 text-sm text-gray-900">{description}</h5>
@@ -67,7 +68,7 @@ const DynamicCard = ({ data, variant = "vertical" }: DynamicCardProps) => {
                   <p className="mb-1 text-xs font-semibold text-gray-500">{category}</p>
                   <h4 className="truncate text-sm font-bold leading-tight text-gray-900">{name}</h4>
                 </div>
-                <FavoriteBtn brandId={brandId} bookmarked={bookmarked} variant={variant} />
+                <FavoriteBtn brandId={brandId} bookmarked={isBookmarked} variant={variant} />
               </div>
               <h5 className="mb-2 line-clamp-2 text-sm text-gray-900">{description}</h5>
               {/* 등급별 배치 */}

--- a/apps/user/src/types/brand.ts
+++ b/apps/user/src/types/brand.ts
@@ -19,7 +19,7 @@ export interface BrandContent {
   /** 혜택을 사용할 수 있는 최소 등급 */
   minRank: "NONE" | "NORMAL" | "PREMIUM";
   /** 사용자가 북마크했는지 여부 */
-  bookmarked?: boolean;
+  isBookmarked?: boolean;
 }
 
 /**
@@ -34,11 +34,26 @@ export interface BrandListData {
   lastCursorId?: number;
 }
 
-interface BrandDetailData extends BrandContent {
+export interface BrandBenefit {
+  benefitId: number;
+  type: string;
+  minRank: "NONE" | "NORMAL" | "PREMIUM" | "VIP";
+  content: string;
+  manual: string;
+  provisionCount: string;
+}
+export interface BrandDetailData {
+  brandId: number;
+  name: string;
   csrNumber: string;
   description: string;
+  imgUrl: string;
   season: string;
   categoryName: string;
+  bookmarkId?: number;
+  benefits: BrandBenefit[];
+  isBookmarked: boolean;
+  isVIPcock: boolean;
 }
 
 /**

--- a/apps/user/src/types/brand.ts
+++ b/apps/user/src/types/brand.ts
@@ -17,7 +17,7 @@ export interface BrandContent {
   /** VIP콕 혜택이 존재하는지 여부 */
   isVIPcock: boolean;
   /** 혜택을 사용할 수 있는 최소 등급 */
-  minRank: "NONE" | "NORMAL" | "PREMIUM";
+  minRank: "NONE" | "NORMAL" | "PREMIUM" | "VIP";
   /** 사용자가 북마크했는지 여부 */
   isBookmarked?: boolean;
 }
@@ -36,7 +36,7 @@ export interface BrandListData {
 
 export interface BrandBenefit {
   benefitId: number;
-  type: string;
+  type: "NORMAL" | "VIP";
   minRank: "NONE" | "NORMAL" | "PREMIUM" | "VIP";
   content: string;
   manual: string;

--- a/apps/user/src/types/brand.ts
+++ b/apps/user/src/types/brand.ts
@@ -1,5 +1,12 @@
 import { responseStatus } from "./api";
 
+export enum Grade {
+  None = "NONE",
+  NORMAL = "NORMAL",
+  PREMIUM = "PREMIUM",
+  VIP = "VIP"
+}
+
 /**
  * 브랜드 단일 항목 타입
  */
@@ -17,7 +24,7 @@ export interface BrandContent {
   /** VIP콕 혜택이 존재하는지 여부 */
   isVIPcock: boolean;
   /** 혜택을 사용할 수 있는 최소 등급 */
-  minRank: "NONE" | "NORMAL" | "PREMIUM" | "VIP";
+  minRank: Grade;
   /** 사용자가 북마크했는지 여부 */
   isBookmarked?: boolean;
 }
@@ -37,7 +44,7 @@ export interface BrandListData {
 export interface BrandBenefit {
   benefitId: number;
   type: "NORMAL" | "VIP";
-  minRank: "NONE" | "NORMAL" | "PREMIUM" | "VIP";
+  minRank: Grade;
   content: string;
   manual: string;
   provisionCount: string;

--- a/apps/user/src/types/brand.ts
+++ b/apps/user/src/types/brand.ts
@@ -1,7 +1,7 @@
 import { responseStatus } from "./api";
 
 export enum Grade {
-  None = "NONE",
+  NONE = "NONE",
   NORMAL = "NORMAL",
   PREMIUM = "PREMIUM",
   VIP = "VIP"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #57 

## 📝작업 내용

제휴처 상세 데이터 타입 정의
제휴처 상세 페이지 routing
제휴처 목록 카드를 클릭 시 상세 페이지로 이동하도록 구현
제휴처 상세 페이지 마크업

## 📷스크린샷 (선택)

<img width="499" height="944" alt="image" src="https://github.com/user-attachments/assets/3455ddc8-47b1-42b2-8607-75398675ef24" />

<img width="499" height="945" alt="image" src="https://github.com/user-attachments/assets/d85978a0-5ab2-4f65-bf41-fa456c05165f" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 브랜드 카드 클릭 시 파트너십 상세 페이지로 이동하는 기능이 추가되었습니다.
  * 파트너십 상세 페이지가 새롭게 도입되어, 브랜드 상세 정보와 혜택 목록을 확인할 수 있습니다.
  * 파트너십 상세 페이지 내 브랜드 정보, 혜택 리스트, 즐겨찾기 버튼 등 다양한 컴포넌트가 추가되었습니다.

* **버그 수정**
  * 즐겨찾기(하트) 버튼의 미선택 상태에서 마우스 오버 시 색상이 변경되는 효과가 추가되었습니다.

* **스타일**
  * 파트너십 상세 페이지 및 카드, 혜택 리스트 등에 Tailwind CSS 기반의 스타일이 적용되었습니다.

* **리팩터**
  * 즐겨찾기 관련 데이터 필드명이 `bookmarked`에서 `isBookmarked`로 변경되었습니다.
  * 브랜드 상세 데이터 구조가 명확하게 분리 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->