### PR TITLE
[FEAT] UBLE-69 사용자 멤버십 바코드 생성

### DIFF
--- a/apps/user/package.json
+++ b/apps/user/package.json
@@ -18,6 +18,7 @@
     "date-fns": "^4.1.0",
     "lucide-react": "^0.475.0",
     "motion": "^12.23.6",
+    "react-barcode": "^1.6.1",
     "react-modal-sheet": "^4.4.0",
     "vaul": "^1.1.2",
     "zustand": "^5.0.6"

--- a/apps/user/src/app/(main)/partnerships/[id]/components/BarcodeBlur.tsx
+++ b/apps/user/src/app/(main)/partnerships/[id]/components/BarcodeBlur.tsx
@@ -1,0 +1,16 @@
+import { Barcode } from "lucide-react";
+
+const BarcodeBlur = () => {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-white/70 backdrop-blur-sm">
+      <div className="text-center">
+        <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-[#41d596]">
+          <Barcode className="h-6 w-6 text-white" />
+        </div>
+        <p className="text-sm font-medium text-gray-700">클릭하여 바코드 활성화</p>
+      </div>
+    </div>
+  );
+};
+
+export default BarcodeBlur;

--- a/apps/user/src/app/(main)/partnerships/[id]/components/BarcodeContainer.tsx
+++ b/apps/user/src/app/(main)/partnerships/[id]/components/BarcodeContainer.tsx
@@ -1,0 +1,35 @@
+"use client";
+import UserBarcode from "@/components/common/UserBarcode";
+import { useState } from "react";
+import BarcodeBlur from "./BarcodeBlur";
+
+const BarcodeContainer = () => {
+  const [isBarcodeRevealed, setIsBarcodeRevealed] = useState(false);
+
+  const handleBarcodeClick = () => {
+    if (!isBarcodeRevealed) {
+      setIsBarcodeRevealed(true);
+    }
+  };
+  return (
+    <div className="space-y-2 pt-4">
+      <h3 className="font-semibold">멤버십 바코드</h3>
+      <div
+        className={`relative cursor-pointer rounded-lg bg-gray-50 p-6 transition-all duration-300 ${
+          !isBarcodeRevealed ? "hover:bg-gray-100" : ""
+        }`}
+        onClick={handleBarcodeClick}
+      >
+        <div className="text-center">
+          <UserBarcode />
+          <div className="space-y-1">
+            <p className="text-xs text-[#41d596]">매장에서 이 바코드를 제시해주세요</p>
+          </div>
+        </div>
+        {!isBarcodeRevealed && <BarcodeBlur />}
+      </div>
+    </div>
+  );
+};
+
+export default BarcodeContainer;

--- a/apps/user/src/app/(main)/partnerships/[id]/components/BarcodeContainer.tsx
+++ b/apps/user/src/app/(main)/partnerships/[id]/components/BarcodeContainer.tsx
@@ -1,10 +1,12 @@
 "use client";
 import UserBarcode from "@/components/common/UserBarcode";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import BarcodeBlur from "./BarcodeBlur";
+import useUserStore from "@/store/useUserStore";
 
 const BarcodeContainer = () => {
   const [isBarcodeRevealed, setIsBarcodeRevealed] = useState(false);
+  const { barcode } = useUserStore((state) => state.user);
 
   const handleBarcodeClick = () => {
     if (!isBarcodeRevealed) {
@@ -16,17 +18,28 @@ const BarcodeContainer = () => {
       <h3 className="font-semibold">멤버십 바코드</h3>
       <div
         className={`relative cursor-pointer rounded-lg bg-gray-50 p-6 transition-all duration-300 ${
-          !isBarcodeRevealed ? "hover:bg-gray-100" : ""
+          !isBarcodeRevealed && barcode ? "hover:bg-gray-100" : ""
         }`}
         onClick={handleBarcodeClick}
       >
         <div className="text-center">
-          <UserBarcode />
-          <div className="space-y-1">
-            <p className="text-xs text-[#41d596]">매장에서 이 바코드를 제시해주세요</p>
-          </div>
+          {barcode ? (
+            <Fragment>
+              <UserBarcode />
+              <div className="space-y-1">
+                <p className="text-xs text-[#41d596]">매장에서 이 바코드를 제시해주세요</p>
+              </div>
+            </Fragment>
+          ) : (
+            <div className="space-y-1">
+              <p className="text-xs text-[#41d596]">
+                바코드를 등록하신 후 LGU+의 다양한 혜택을 이용하세요!
+              </p>
+              <p className="text-xs text-[#41d596]">혜택 사용 시 사용자 맞춤 제휴처가 추천됩니다</p>
+            </div>
+          )}
         </div>
-        {!isBarcodeRevealed && <BarcodeBlur />}
+        {!isBarcodeRevealed && barcode && <BarcodeBlur />}
       </div>
     </div>
   );

--- a/apps/user/src/app/(main)/partnerships/[id]/components/PartnershipContainer.tsx
+++ b/apps/user/src/app/(main)/partnerships/[id]/components/PartnershipContainer.tsx
@@ -6,6 +6,8 @@ import { apiHandler } from "@api/apiHandler";
 import { fetchBrandDetail } from "@/service/brand";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import UserBarcode from "@/components/common/UserBarcode";
+import BarcodeContainer from "./BarcodeContainer";
 
 const PartnershipContainer = ({ id }: { id: string }) => {
   const router = useRouter();
@@ -47,6 +49,7 @@ const PartnershipContainer = ({ id }: { id: string }) => {
       <div className="space-y-4 p-4">
         <PartnershipHeader {...data} />
         <PartnershipBenefitList {...data} />
+        <BarcodeContainer />
       </div>
     </div>
   );

--- a/apps/user/src/app/(no-layout)/signup/components/InputBarcode.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/InputBarcode.tsx
@@ -1,28 +1,29 @@
-'use client'
+"use client";
 import { Input } from "@workspace/ui/components/input";
 import { useState } from "react";
 
-
-const InputBarcodeNumber = () => {
-  const [barcodeNumber, setBarcodeNumber] = useState("");
+const Inputbarcode = () => {
+  const [barcode, setbarcode] = useState("");
 
   const handleBarcodeChange = (value: string) => {
     // 숫자만 추출 음수 입력 방지
     const numbers = value.replace(/\D/g, "");
     // 0으로 시작하는 경우도 허용, 빈 값도 허용
     if (numbers === "" || /^[0-9]+$/.test(numbers)) {
-      setBarcodeNumber(numbers);
+      setbarcode(numbers);
     }
   };
   return (
     <div className="space-y-8">
       <div className="space-y-2">
-        <h1 className="text-xl font-semibold text-gray-900 leading-tight">
+        <h1 className="text-xl font-semibold leading-tight text-gray-900">
           멤버십 바코드 번호를
           <br />
           입력해주세요
         </h1>
-        <p className="text-sm text-gray-500 font-medium">기존 멤버십 바코드가 있다면 입력해주세요 (선택사항)</p>
+        <p className="text-sm font-medium text-gray-500">
+          기존 멤버십 바코드가 있다면 입력해주세요 (선택사항)
+        </p>
       </div>
 
       <div className="space-y-6">
@@ -32,17 +33,17 @@ const InputBarcodeNumber = () => {
             inputMode="numeric"
             pattern="[0-9]*"
             placeholder="바코드 번호 입력 (숫자만)"
-            value={barcodeNumber}
+            value={barcode}
             onChange={(e) => handleBarcodeChange(e.target.value)}
             variant="default"
-            className="w-full h-12 text-base font-medium"
+            className="h-12 w-full text-base font-medium"
             maxLength={16}
           />
         </div>
 
-        <div className="bg-gray-50 rounded-lg p-4">
-          <h3 className="text-sm font-medium text-gray-900 mb-2">안내사항</h3>
-          <ul className="text-xs text-gray-600 space-y-1">
+        <div className="rounded-lg bg-gray-50 p-4">
+          <h3 className="mb-2 text-sm font-medium text-gray-900">안내사항</h3>
+          <ul className="space-y-1 text-xs text-gray-600">
             <li>• 바코드 번호는 16자리 숫자입니다</li>
             <li>• 잘못된 번호 입력 시 나중에 수정할 수 있습니다</li>
             <li>• 입력하지 않아도 서비스 이용이 가능합니다</li>
@@ -53,4 +54,4 @@ const InputBarcodeNumber = () => {
   );
 };
 
-export default InputBarcodeNumber;
+export default Inputbarcode;

--- a/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
@@ -24,7 +24,7 @@ const NextStepBtn = ({ currentStep, canProceed, setCurrentStep, info }: NextStep
 
   const handleNext = async () => {
     // 바코드 번호가 1~15자리면 진행 불가
-    if (info.barcodeNumber && info.barcodeNumber.length > 0 && info.barcodeNumber.length <= 15) {
+    if (info.barcode && info.barcode.length > 0 && info.barcode.length <= 15) {
       alert("바코드 번호는 16자리 입니다.");
       return;
     }

--- a/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
@@ -1,11 +1,11 @@
-'use client'
-import { setUserInfo } from '@/service/user';
-import { TOTAL_STEPS } from '@/types/constants';
-import { InfoForm } from '@/types/profile';
-import { apiHandler } from '@api/apiHandler';
-import { Button } from '@workspace/ui/components/button';
-import { useRouter } from 'next/navigation';
-import { Dispatch, SetStateAction } from 'react';
+"use client";
+import { setUserInfo } from "@/service/user";
+import { TOTAL_STEPS } from "@/types/constants";
+import { InfoForm } from "@/types/profile";
+import { apiHandler } from "@api/apiHandler";
+import { Button } from "@workspace/ui/components/button";
+import { useRouter } from "next/navigation";
+import { Dispatch, SetStateAction } from "react";
 
 interface NextStepBtnProps {
   currentStep: number;
@@ -20,27 +20,34 @@ const NextStepBtn = ({ currentStep, canProceed, setCurrentStep, info }: NextStep
     const { data } = await apiHandler(() => setUserInfo(info));
     const result = data?.statusCode;
     return result === 0 ? true : false;
-  }
+  };
 
   const handleNext = async () => {
+    // 바코드 번호가 1~15자리면 진행 불가
+    if (info.barcodeNumber && info.barcodeNumber.length > 0 && info.barcodeNumber.length <= 15) {
+      alert("바코드 번호는 16자리 입니다.");
+      return;
+    }
     if (currentStep < TOTAL_STEPS) {
-      setCurrentStep(currentStep + 1)
+      setCurrentStep(currentStep + 1);
     } else {
       const storeResult = await storeUserInfo();
       if (storeResult) {
-        router.push("/home")
-      }
-      else alert("정보 저장을 실패했습니다.");
+        router.push("/home");
+      } else alert("정보 저장을 실패했습니다.");
     }
-  }
+  };
 
   return (
     <div className="p-5 pt-0">
       <Button
         onClick={handleNext}
         disabled={!canProceed()}
-        className={`w-full h-12 text-sm font-semibold rounded-lg transition-all ${canProceed() ? "bg-[#41d596] hover:bg-[#14B470] text-white" : "bg-gray-200 text-gray-400 cursor-not-allowed"
-          }`}
+        className={`h-12 w-full rounded-lg text-sm font-semibold transition-all ${
+          canProceed()
+            ? "bg-[#41d596] text-white hover:bg-[#14B470]"
+            : "cursor-not-allowed bg-gray-200 text-gray-400"
+        }`}
       >
         {currentStep === TOTAL_STEPS ? "시작하기" : "다음"}
       </Button>

--- a/apps/user/src/app/(no-layout)/signup/components/SignupContainer.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SignupContainer.tsx
@@ -1,10 +1,10 @@
-'use client'
+"use client";
 import { useState } from "react";
 import SelectMembership from "./SelectMembership";
 import SelectGender from "./SelectGender";
 import InputBirth from "./InputBirth";
 import SelectCategory from "./SelectCategory";
-import InputBarcodeNumber from "./InputBarcodeNumber";
+import Inputbarcode from "./InputBarcode";
 import ProgressHeader from "./ProgressHeader";
 import { InfoForm, StepProps } from "@/types/profile";
 import NextStepBtn from "./NextStepBtn";
@@ -14,7 +14,7 @@ const stepComponentMap: Record<number, React.ComponentType<StepProps>> = {
   2: SelectGender,
   3: InputBirth,
   4: SelectCategory,
-  5: InputBarcodeNumber,
+  5: Inputbarcode,
 };
 
 const SignupContainer = () => {
@@ -24,33 +24,38 @@ const SignupContainer = () => {
     gender: "",
     birthDate: "",
     categoryIds: [],
-  })
+  });
   const StepComponent = stepComponentMap[currentStep];
 
   const canProceed = () => {
     switch (currentStep) {
       case 1:
-        return info.rank !== ""
+        return info.rank !== "";
       case 2:
-        return info.gender !== ""
+        return info.gender !== "";
       case 3:
-        return info.birthDate !== ""
+        return info.birthDate !== "";
       case 4:
-        return info.categoryIds.length > 0
+        return info.categoryIds.length > 0;
       case 5:
-        return true // 바코드는 필수가 아님
+        return true; // 바코드는 필수가 아님
       default:
-        return false
+        return false;
     }
-  }
+  };
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
+    <div className="flex min-h-screen flex-col bg-white">
       <ProgressHeader currentStep={currentStep} setCurrentStep={setCurrentStep} />
       <div className="flex-1 px-5 py-4">
         {StepComponent ? <StepComponent info={info} setInfo={setInfo} /> : null}
       </div>
-      <NextStepBtn currentStep={currentStep} setCurrentStep={setCurrentStep} canProceed={canProceed} info={info} />
+      <NextStepBtn
+        currentStep={currentStep}
+        setCurrentStep={setCurrentStep}
+        canProceed={canProceed}
+        info={info}
+      />
     </div>
   );
 };

--- a/apps/user/src/components/common/UserBarcode.tsx
+++ b/apps/user/src/components/common/UserBarcode.tsx
@@ -1,0 +1,20 @@
+import useUserStore from "@/store/useUserStore";
+import Barcode from "react-barcode";
+const UserBarcode = () => {
+  const { user } = useUserStore();
+  if (user.barcode)
+    return (
+      <div className="flex justify-center">
+        <Barcode
+          value={user.barcode}
+          font="pretendard"
+          format="ITF"
+          width={2}
+          height={80}
+          fontSize={18}
+        />
+      </div>
+    );
+};
+
+export default UserBarcode;

--- a/apps/user/src/components/common/UserBarcode.tsx
+++ b/apps/user/src/components/common/UserBarcode.tsx
@@ -12,6 +12,7 @@ const UserBarcode = () => {
           width={2}
           height={80}
           fontSize={18}
+          background="#F9FAFB"
         />
       </div>
     );

--- a/apps/user/src/components/modal/ProfileEditModal.tsx
+++ b/apps/user/src/components/modal/ProfileEditModal.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 import { Fragment, useState } from "react";
 import { Button } from "@workspace/ui/components/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@workspace/ui/components/dialog";
@@ -15,8 +15,7 @@ import SaveButton from "./ProfileEditModalContents/SaveButton";
 const ProfileEditModal = () => {
   const { isOpen, close } = useProfileEditModalStore();
   const { user } = useUserStore();
-  const { rank, gender, birthDate, categoryIds, barcodeNumber } = user;
-
+  const { rank, gender, birthDate, categoryIds, barcode } = user;
 
   // formData 객체로 state 관리
   const [formData, setFormData] = useState<UserInfo>({
@@ -24,69 +23,60 @@ const ProfileEditModal = () => {
     gender: gender,
     birthDate: birthDate,
     categoryIds: categoryIds ?? [],
-    barcodeNumber: barcodeNumber || '',
+    barcode: barcode || "",
   });
-
 
   // 핸들러들
   const handleRankChange = (grade: string) => setFormData((prev) => ({ ...prev, rank: grade }));
-  const handleGenderChange = (korGender: "MALE" | "FEMALE") => setFormData((prev) => ({ ...prev, gender: korGender }));
+  const handleGenderChange = (korGender: "MALE" | "FEMALE") =>
+    setFormData((prev) => ({ ...prev, gender: korGender }));
   const handleBirthDateChange = (date: string | undefined) => {
-    setFormData((prev) => ({ ...prev, birthDate: date ? date : '' }));
+    setFormData((prev) => ({ ...prev, birthDate: date ? date : "" }));
   };
-  const handleBarcodeChange = (value: string) => setFormData((prev) => ({ ...prev, barcodeNumber: value }));
+  const handleBarcodeChange = (value: string) =>
+    setFormData((prev) => ({ ...prev, barcode: value }));
 
   return (
     <Dialog open={isOpen} onOpenChange={close}>
-      <DialogContent className="max-w-md max-h-[90vh] overflow-hidden flex flex-col">
+      <DialogContent className="flex max-h-[90vh] max-w-md flex-col overflow-hidden">
         <DialogHeader className="flex-shrink-0">
           <DialogTitle className="text-lg font-semibold">프로필 수정</DialogTitle>
         </DialogHeader>
         {user.nickname === "" ? (
           <div className="flex flex-col items-center justify-center py-12">
             <p className="text-gray-500">사용자 정보를 불러올 수 없습니다.</p>
-            <Button className="mt-4" onClick={close}>닫기</Button>
+            <Button className="mt-4" onClick={close}>
+              닫기
+            </Button>
           </div>
         ) : (
           <Fragment>
             <div className="flex-1 overflow-y-auto px-1">
               <div className="space-y-6 py-4">
                 {/* 요금제 등급 */}
-                <MembershipGradeSelector
-                  grade={formData.rank}
-                  onChange={handleRankChange}
-                />
+                <MembershipGradeSelector grade={formData.rank} onChange={handleRankChange} />
                 {/* 성별 */}
                 <GenderSelector
                   gender={formData.gender as "MALE" | "FEMALE"}
                   onChange={handleGenderChange}
                 />
                 {/* 생년월일 */}
-                <BirthDateSelector
-                  value={formData.birthDate}
-                  onChange={handleBirthDateChange}
-                />
+                <BirthDateSelector value={formData.birthDate} onChange={handleBirthDateChange} />
                 {/* 관심 분야 */}
                 <CategorySelector
                   categoryIds={formData.categoryIds}
                   onChange={(ids) => setFormData((prev) => ({ ...prev, categoryIds: ids }))}
                 />
                 {/* 멤버십 바코드 번호 */}
-                <BarcodeInput
-                  value={formData.barcodeNumber || ""}
-                  onChange={handleBarcodeChange}
-                />
+                <BarcodeInput value={formData.barcode || ""} onChange={handleBarcodeChange} />
               </div>
             </div>
 
-            <div className="flex-shrink-0 flex space-x-3 pt-4">
+            <div className="flex flex-shrink-0 space-x-3 pt-4">
               <Button variant="outline" onClick={close} className="flex-1 bg-transparent">
                 취소
               </Button>
-              <SaveButton
-                formData={formData}
-                user={user}
-              />
+              <SaveButton formData={formData} user={user} />
             </div>
           </Fragment>
         )}

--- a/apps/user/src/components/modal/ProfileEditModalContents/SaveButton.tsx
+++ b/apps/user/src/components/modal/ProfileEditModalContents/SaveButton.tsx
@@ -17,7 +17,7 @@ const SaveButton = ({ formData, user }: SaveButtonProps) => {
     formData.rank !== user.rank ||
     formData.gender !== user.gender ||
     formData.birthDate !== user.birthDate ||
-    formData.barcodeNumber !== (user.barcodeNumber || '') ||
+    formData.barcodeNumber !== (user.barcodeNumber || "") ||
     formData.categoryIds?.length !== user.categoryIds?.length ||
     !formData.categoryIds.every((id) => user.categoryIds.includes(id));
 
@@ -26,6 +26,9 @@ const SaveButton = ({ formData, user }: SaveButtonProps) => {
     !!formData.gender &&
     !!formData.birthDate &&
     formData.categoryIds?.length > 0 &&
+    (!formData.barcodeNumber ||
+      formData.barcodeNumber.length === 0 ||
+      formData.barcodeNumber.length > 15) &&
     isChanged;
 
   const handleEditUserInfo = async () => {
@@ -35,9 +38,8 @@ const SaveButton = ({ formData, user }: SaveButtonProps) => {
       setUser(formData);
       alert("정보가 수정되었습니다.");
       close();
-    }
-    else alert("사용자 정보 수정에 실패했습니다.");
-  }
+    } else alert("사용자 정보 수정에 실패했습니다.");
+  };
 
   return (
     <Button
@@ -50,4 +52,4 @@ const SaveButton = ({ formData, user }: SaveButtonProps) => {
   );
 };
 
-export default SaveButton; 
+export default SaveButton;

--- a/apps/user/src/components/modal/ProfileEditModalContents/SaveButton.tsx
+++ b/apps/user/src/components/modal/ProfileEditModalContents/SaveButton.tsx
@@ -35,8 +35,8 @@ const SaveButton = ({ formData, user }: SaveButtonProps) => {
     // 여기에 유저 정보 수정 로직 구현 후 모달 닫음
     const { data } = await apiHandler(() => setUserInfo(formData));
     if (data?.statusCode === 0) {
-      setUser(formData);
       alert("정보가 수정되었습니다.");
+      setUser({ ...formData, nickname: user.nickname });
       close();
     } else alert("사용자 정보 수정에 실패했습니다.");
   };

--- a/apps/user/src/components/modal/ProfileEditModalContents/SaveButton.tsx
+++ b/apps/user/src/components/modal/ProfileEditModalContents/SaveButton.tsx
@@ -17,7 +17,7 @@ const SaveButton = ({ formData, user }: SaveButtonProps) => {
     formData.rank !== user.rank ||
     formData.gender !== user.gender ||
     formData.birthDate !== user.birthDate ||
-    formData.barcodeNumber !== (user.barcodeNumber || "") ||
+    formData.barcode !== (user.barcode || "") ||
     formData.categoryIds?.length !== user.categoryIds?.length ||
     !formData.categoryIds.every((id) => user.categoryIds.includes(id));
 
@@ -26,9 +26,7 @@ const SaveButton = ({ formData, user }: SaveButtonProps) => {
     !!formData.gender &&
     !!formData.birthDate &&
     formData.categoryIds?.length > 0 &&
-    (!formData.barcodeNumber ||
-      formData.barcodeNumber.length === 0 ||
-      formData.barcodeNumber.length > 15) &&
+    (!formData.barcode || formData.barcode.length === 0 || formData.barcode.length > 15) &&
     isChanged;
 
   const handleEditUserInfo = async () => {

--- a/apps/user/src/store/useUserStore.ts
+++ b/apps/user/src/store/useUserStore.ts
@@ -1,5 +1,5 @@
-import { UserInfo } from '@/types/profile';
-import { create } from 'zustand';
+import { UserInfo } from "@/types/profile";
+import { create } from "zustand";
 
 interface UserStore {
   user: UserInfo;
@@ -14,10 +14,10 @@ const useUserStore = create<UserStore>((set) => ({
     gender: "MALE",
     birthDate: "",
     categoryIds: [],
-    barcodeNumber: "",
+    barcode: "",
   },
   setUser: (user) => set({ user }),
   updateUser: (fields) => set((state) => ({ user: { ...state.user, ...fields } })),
 }));
 
-export default useUserStore; 
+export default useUserStore;

--- a/apps/user/src/types/profile.ts
+++ b/apps/user/src/types/profile.ts
@@ -24,12 +24,13 @@ export interface InfoForm {
   gender: string;
   birthDate: string;
   categoryIds: number[];
+  barcodeNumber?: string;
 }
 
 export interface StepProps {
   info: InfoForm;
   setInfo: Dispatch<SetStateAction<InfoForm>>;
-};
+}
 
 export interface SetUserInfo extends responseStatus {
   data: InfoForm;

--- a/apps/user/src/types/profile.ts
+++ b/apps/user/src/types/profile.ts
@@ -7,7 +7,7 @@ export interface UserInfo {
   gender: "MALE" | "FEMALE";
   birthDate: string;
   categoryIds: number[];
-  barcodeNumber?: string;
+  barcode?: string;
 }
 
 export interface UserStatistics {
@@ -24,7 +24,7 @@ export interface InfoForm {
   gender: string;
   birthDate: string;
   categoryIds: number[];
-  barcodeNumber?: string;
+  barcode?: string;
 }
 
 export interface StepProps {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       motion:
         specifier: ^12.23.6
         version: 12.23.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-barcode:
+        specifier: ^1.6.1
+        version: 1.6.1(react@19.1.0)
       react-modal-sheet:
         specifier: ^4.4.0
         version: 4.4.0(motion@12.23.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
@@ -3107,6 +3110,9 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  jsbarcode@3.12.1:
+    resolution: {integrity: sha512-QZQSqIknC2Rr/YOUyOkCBqsoiBAOTYK+7yNN3JsqfoUtJtkazxNw1dmPpxuv7VVvqW13kA3/mKiLq+s/e3o9hQ==}
+
   jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
 
@@ -3714,6 +3720,11 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
+
+  react-barcode@1.6.1:
+    resolution: {integrity: sha512-pc4ftnO5syHa/UjCruEeRsomlhoxKSugIgTA8T4dH0fvc89UMHL+/1Sp25IAphqG44pJkE5hMXhv89iS09jQyw==}
+    peerDependencies:
+      react: 16 - 19
 
   react-day-picker@9.8.0:
     resolution: {integrity: sha512-E0yhhg7R+pdgbl/2toTb0xBhsEAtmAx1l7qjIWYfcxOy8w4rTSVfbtBoSzVVhPwKP/5E9iL38LivzoE3AQDhCQ==}
@@ -7494,6 +7505,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsbarcode@3.12.1: {}
+
   jsbn@1.1.0: {}
 
   jsesc@3.1.0: {}
@@ -8033,6 +8046,12 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  react-barcode@1.6.1(react@19.1.0):
+    dependencies:
+      jsbarcode: 3.12.1
+      prop-types: 15.8.1
+      react: 19.1.0
 
   react-day-picker@9.8.0(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #64 

## 📝작업 내용

사용자 정보의 barcodeNumber를 사용하여 바코드를 생성한다.

제휴처 상세 페이지의 하단에서 사용자는 바코드 blur를 해제한 후 실제로 사용할 수 있다.

사용자 최초 회원 가입 시, 사용자 정보 수정 시 1~15자리의 바코드는 등록할 수 없다.

사용자 정보를 수정한 직후 사용자 정보가 정보가 출력되지 않는 버그 수정

## 📷스크린샷 (선택)
<img width="489" height="130" alt="image" src="https://github.com/user-attachments/assets/88b11cbf-d49c-4f17-839c-e673c29f036f" />

<img width="494" height="229" alt="image" src="https://github.com/user-attachments/assets/943c4f21-4be5-46b9-9d35-f0cdadf1fc67" />

<img width="321" height="175" alt="image" src="https://github.com/user-attachments/assets/cca1ffa1-8c3b-4b91-8b24-6062a8e37042" />

## 💬리뷰 요구사항(선택)

