### PR TITLE
[FEAT] 자주가는 장소 API 연동 및 전역 confirm 모달 생성

### DIFF
--- a/apps/user/src/app/(main)/layout.tsx
+++ b/apps/user/src/app/(main)/layout.tsx
@@ -4,6 +4,7 @@ import Header from "../../components/common/Header";
 import HydrateData from "@/components/HydrateData";
 import { Fragment } from "react";
 import { ReactQueryProvider } from "./providers";
+import ConfirmModal from "@/components/common/ConfirmModal";
 
 export default function RootLayout({
   children,
@@ -13,6 +14,7 @@ export default function RootLayout({
   return (
     <Fragment>
       <HydrateData />
+      <ConfirmModal />
       <Header />
       <ReactQueryProvider>
         <main style={{ paddingBottom: "72px" }}>{children}</main>

--- a/apps/user/src/app/(main)/map/components/MyPlaceCard.tsx
+++ b/apps/user/src/app/(main)/map/components/MyPlaceCard.tsx
@@ -1,7 +1,12 @@
-import { Button } from "@workspace/ui/components/button";
 import { Pencil, Star, Trash2 } from "lucide-react";
+import { Button } from "@workspace/ui/components/button";
+import { deleteMyPlace } from "@/service/map";
+import { useMapStore } from "@/store/useMapStore";
+import { toast } from "sonner";
+import useConfirmModalStore from "@/store/useConfirmModalStore";
 
 interface MyPlaceCardProps {
+  placeId: number;
   name: string;
   address?: string;
   selected?: boolean;
@@ -9,24 +14,38 @@ interface MyPlaceCardProps {
 }
 
 export default function MyPlaceCard({
+  placeId,
   name,
   address,
   selected = false,
   onClick,
 }: MyPlaceCardProps) {
-  // 내 장소명 변경
-  const handleEditName = () => {
-    alert("장소명 수정");
-  };
+  const removeMyPlace = useMapStore((s) => s.removeMyPlace);
 
-  // 내 장소 주소값 변경
-  const handleEditAddress = () => {
-    alert("주소 수정");
-  };
+  // TODO: 내 장소명 변경
+  const handleEditName = () => {};
+
+  // TODO: 내 장소 주소값 변경
+  const handleEditAddress = () => {};
 
   // 내 장소 삭제
   const handleDelete = () => {
-    alert("장소 삭제");
+    const { open } = useConfirmModalStore.getState();
+
+    open({
+      message: "장소를 삭제하시겠어요?",
+      confirmText: "삭제",
+      cancelText: "취소",
+      onConfirm: async () => {
+        try {
+          await deleteMyPlace(placeId);
+          removeMyPlace(placeId); // zustand store에서 제거
+          toast.success("삭제되었습니다.");
+        } catch {
+          toast.error("장소 삭제에 실패했습니다.");
+        }
+      },
+    });
   };
 
   return (

--- a/apps/user/src/app/(main)/map/components/MyPlaceList.tsx
+++ b/apps/user/src/app/(main)/map/components/MyPlaceList.tsx
@@ -3,16 +3,18 @@ import { MyPlace } from "@/types/map";
 
 interface MyPlaceListProps {
   places: MyPlace[];
-  selectedPlaceId: string | null;
-  onSelect: (id: string) => void;
+  selectedPlaceId: number | null;
+  onSelect: (id: number) => void;
 }
 
 const MyPlaceList = ({ places, selectedPlaceId, onSelect }: MyPlaceListProps) => {
+  console.log(places);
   return (
     <>
       {places.map((place) => (
         <MyPlaceCard
           key={place.id}
+          placeId={place.id}
           name={place.name}
           address={place.address}
           selected={selectedPlaceId === place.id}

--- a/apps/user/src/components/common/ConfirmModal.tsx
+++ b/apps/user/src/components/common/ConfirmModal.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@workspace/ui/components/dialog";
+import { Button } from "@workspace/ui/components/button";
+import useConfirmModalStore from "@/store/useConfirmModalStore";
+import { useState } from "react";
+
+const ConfirmModal = () => {
+  const { isOpen, message, confirmText, cancelText, onConfirm, close } = useConfirmModalStore();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleConfirm = async () => {
+    if (!onConfirm) return close();
+    try {
+      setIsLoading(true);
+      await onConfirm();
+    } finally {
+      setIsLoading(false);
+      close();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={close}>
+      <DialogContent className="w-full max-w-xs">
+        <DialogHeader>
+          <DialogTitle className="text-center text-lg font-semibold">{message}</DialogTitle>
+        </DialogHeader>
+        <div className="flex justify-center space-x-3 pt-2">
+          <Button variant="modal_cancel" onClick={close}>
+            {cancelText}
+          </Button>
+          <Button variant="modal_submit" onClick={handleConfirm} disabled={isLoading}>
+            {confirmText}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ConfirmModal;

--- a/apps/user/src/hooks/map/useStorePins.ts
+++ b/apps/user/src/hooks/map/useStorePins.ts
@@ -35,18 +35,20 @@ export function useStorePins(baseLocation: Coordinates | null, selectedCategory:
 
       setPins([
         {
-          id: 0,
+          id: -1,
           coords: baseLocation,
-          name: selectedPlaceId === "current" ? "현위치" : "저장위치",
+          name: selectedPlaceId === -1 ? "현위치" : "저장위치",
+          type: "current",
         },
         ...storePins,
       ]);
     } catch (error) {
       setPins([
         {
-          id: 0,
+          id: -1,
           coords: baseLocation,
-          name: selectedPlaceId === "current" ? "현위치" : "저장위치",
+          name: selectedPlaceId === -1 ? "현위치" : "저장위치",
+          type: "current",
         },
       ]);
     } finally {
@@ -57,7 +59,7 @@ export function useStorePins(baseLocation: Coordinates | null, selectedCategory:
   useEffect(() => {
     if (!baseLocation || baseLocation === DEFAULT_LOCATION) return;
     fetchPins(baseLocation);
-  }, [baseLocation, selectedCategory.categoryId]);
+  }, [baseLocation, selectedCategory]);
 
   return pins;
 }

--- a/apps/user/src/service/map.ts
+++ b/apps/user/src/service/map.ts
@@ -1,0 +1,61 @@
+import api from "@api/http-commons";
+import { apiHandler } from "@api/apiHandler";
+import { MyPlace, FetchMyPlacesResponse, PostMyPlacesResponse } from "@/types/map";
+
+export interface PostMyPlaceParams {
+  name: string;
+  longitude: number;
+  latitude: number;
+  address: string;
+}
+
+// 장소 등록
+export const postMyPlace = async (params: PostMyPlaceParams): Promise<MyPlace> => {
+  const { data, error } = await apiHandler(async () => {
+    return await api.post<PostMyPlacesResponse>("/api/users/pin", params);
+  });
+
+  if (error || !data) {
+    throw new Error(error || "내 장소 등록 실패");
+  }
+
+  const { pinId, name, address, longitude, latitude } = data.data.data;
+
+  return {
+    id: pinId,
+    name,
+    address,
+    coordinates: [longitude, latitude],
+  };
+};
+
+// 장소 조회
+export const fetchMyPlaces = async (): Promise<MyPlace[]> => {
+  const { data, error } = await apiHandler(async () => {
+    const res = await api.get<FetchMyPlacesResponse>("/api/users/pin");
+    console.log(res);
+    return res.data.data;
+  });
+
+  if (error || !data) {
+    throw new Error(error || "내 장소 조회 실패");
+  }
+
+  return data.locations.map((item) => ({
+    id: item.id,
+    name: item.name,
+    address: item.address,
+    coordinates: [item.longitude, item.latitude],
+  }));
+};
+
+// 장소 삭제
+export const deleteMyPlace = async (pinId: number): Promise<void> => {
+  const { error } = await apiHandler(async () => {
+    await api.delete(`/api/users/pin/${pinId}`);
+  });
+
+  if (error) {
+    throw new Error(error || "삭제 실패");
+  }
+};

--- a/apps/user/src/store/useConfirmModalStore.ts
+++ b/apps/user/src/store/useConfirmModalStore.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+
+interface ConfirmModalState {
+  isOpen: boolean;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: () => void;
+  open: (options: {
+    message: string;
+    confirmText?: string;
+    cancelText?: string;
+    onConfirm?: () => void;
+  }) => void;
+  close: () => void;
+}
+
+const useConfirmModalStore = create<ConfirmModalState>((set) => ({
+  isOpen: false,
+  message: "",
+  confirmText: "확인",
+  cancelText: "취소",
+  onConfirm: undefined,
+  open: ({ message, confirmText = "확인", cancelText = "취소", onConfirm }) =>
+    set({ isOpen: true, message, confirmText, cancelText, onConfirm }),
+  close: () =>
+    set({
+      isOpen: false,
+      message: "",
+      confirmText: "확인",
+      cancelText: "취소",
+      onConfirm: undefined,
+    }),
+}));
+
+export default useConfirmModalStore;

--- a/apps/user/src/store/useLocationStore.ts
+++ b/apps/user/src/store/useLocationStore.ts
@@ -1,0 +1,12 @@
+import { Coordinates } from "@/types/map";
+import { create } from "zustand";
+
+interface LocationState {
+  currentLocation: Coordinates | null; // 현재 GPS 위치
+  setCurrentLocation: (loc: Coordinates) => void;
+}
+
+export const useLocationStore = create<LocationState>((set) => ({
+  currentLocation: null,
+  setCurrentLocation: (loc) => set({ currentLocation: loc }),
+}));

--- a/apps/user/src/store/useMapStore.ts
+++ b/apps/user/src/store/useMapStore.ts
@@ -1,21 +1,26 @@
 import { create } from "zustand";
 import { MyPlace } from "@/types/map";
+import { CURRENT_LOCATION_ID } from "@/types/constants";
 
 interface MapState {
   myPlaces: MyPlace[];
   addMyPlace: (place: MyPlace) => void;
+  removeMyPlace: (id: number) => void;
+  setMyPlaces: (places: MyPlace[]) => void;
 
-  selectedPlaceId: string;
-  setSelectedPlaceId: (id: string) => void;
+  selectedPlaceId: number;
+  setSelectedPlaceId: (id: number) => void;
 }
 
 export const useMapStore = create<MapState>((set) => ({
   myPlaces: [],
-  addMyPlace: (place) =>
+  addMyPlace: (place) => set((state) => ({ myPlaces: [...state.myPlaces, place] })),
+  removeMyPlace: (id) =>
     set((state) => ({
-      myPlaces: [...state.myPlaces, place],
+      myPlaces: state.myPlaces.filter((p) => p.id !== id),
     })),
+  setMyPlaces: (places) => set({ myPlaces: places }),
 
-  selectedPlaceId: "current",
+  selectedPlaceId: CURRENT_LOCATION_ID,
   setSelectedPlaceId: (id) => set({ selectedPlaceId: id }),
 }));

--- a/apps/user/src/types/constants.ts
+++ b/apps/user/src/types/constants.ts
@@ -48,3 +48,5 @@ export const ANY_CATEGORIES: Category[] = [
 ];
 
 export const MEMBERSHIP_GRADES = ["VVIP", "VIP", "우수", "일반"];
+
+export const CURRENT_LOCATION_ID = -1;

--- a/apps/user/src/types/map.ts
+++ b/apps/user/src/types/map.ts
@@ -1,3 +1,5 @@
+import { responseStatus } from "./api";
+
 // 좌표 타입 (사용자 정의)
 export type Coordinates = [number, number]; // [longitude, latitude]
 
@@ -28,8 +30,33 @@ export interface GeocodingResult {
 }
 
 export interface MyPlace {
-  id: string;
+  id: number;
   name: string;
   address: string;
   coordinates: Coordinates;
+}
+
+export interface RawMyPlaceFromGet {
+  id: number;
+  name: string;
+  longitude: number;
+  latitude: number;
+  address: string;
+}
+
+export interface RawMyPlaceFromPost {
+  pinId: number;
+  name: string;
+  longitude: number;
+  latitude: number;
+  address: string;
+}
+
+export interface PostMyPlacesResponse extends responseStatus {
+  data: RawMyPlaceFromPost;
+}
+export interface FetchMyPlacesResponse extends responseStatus {
+  data: {
+    locations: RawMyPlaceFromGet[];
+  };
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#71 

## 📝작업 내용

- 자주가는 장소 서비스 함수 생성
- 자주가는 장소 API (등록, 조회, 삭제) 연동
- 전역 confirm 모달 생성

## 📷스크린샷 (선택)
- 자주가는 곳 등록 및 조회
<img width="359" height="782" alt="스크린샷 2025-07-24 오후 12 39 11" src="https://github.com/user-attachments/assets/f73873cb-7fe6-47f7-a91e-12d6271080df" />
<img width="359" height="782" alt="스크린샷 2025-07-24 오후 12 39 19" src="https://github.com/user-attachments/assets/ad267177-380e-4aaa-8a50-90aa4d0d51e8" />

- 자주가는 곳 삭제
<img width="359" height="782" alt="스크린샷 2025-07-24 오후 12 39 23" src="https://github.com/user-attachments/assets/40f9e2f7-1c96-4dfa-a556-855d2e7a5ad0" />


## 💬리뷰 요구사항(선택)

