### PR TITLE
[FEAT] UBLE-78 유저 통계 출력

### DIFF
--- a/apps/user/src/app/(main)/mypage/components/ProfileStatistics.tsx
+++ b/apps/user/src/app/(main)/mypage/components/ProfileStatistics.tsx
@@ -1,28 +1,80 @@
-import { UserStatistics } from '@/types/profile';
-import { BarChart3 } from 'lucide-react';
-import { Fragment } from 'react';
+"use client";
+import { fetchUserStatistics } from "@/service/user";
+import { StaticsPreviewResponse, UserStatistics } from "@/types/profile";
+import { useQuery } from "@tanstack/react-query";
+import { BarChart3 } from "lucide-react";
+import { Fragment } from "react";
 
 const ProfileStatistics = () => {
-  const userStats: UserStatistics = {
-    category: "카페",
-    total: 30
+  const month = new Date().getMonth() + 1;
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["userStatistics"] as const,
+    queryFn: fetchUserStatistics,
+    select: (res: StaticsPreviewResponse) => res.data,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-32 items-center justify-center">
+        <BarChart3 className="h-6 w-6 animate-spin text-gray-400" />
+        <span className="ml-2 text-gray-600">{`${month}월 통계 로딩 중…`}</span>
+      </div>
+    );
   }
+
+  if (isError) {
+    return (
+      <div className="text-center text-red-500">
+        {`${month}월 통계 조회 중 에러 발생: ${(error as Error).message}`}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <div className="text-center text-gray-500">{`${month}월 통계 데이터가 없습니다.`}</div>;
+  }
+
+  const { monthlyUsedCount, mostUsedBrandName, mostUsedCategoryName } = data;
+
+  // 아직 한 번도 사용한 카테고리가 없을 때
+  if (mostUsedCategoryName === null) {
+    return (
+      <Fragment>
+        <div className="mb-4 flex items-center space-x-2">
+          <BarChart3 className="h-5 w-5 text-gray-600" />
+          <h3 className="font-semibold text-gray-900">{`나의 ${month}월 통계`}</h3>
+        </div>
+        <div className="flex h-20 flex-col items-center justify-center space-y-1 text-center">
+          <p>{month}월엔 아직 혜택을 사용하지 않으셨네요!</p>
+          <p>지도에서 주변 혜택을 찾아보세요!</p>
+        </div>
+      </Fragment>
+    );
+  }
+
+  // 정상 렌더링
   return (
     <Fragment>
-      <div className="flex items-center space-x-2 mb-4">
+      <div className="mb-4 flex items-center space-x-2">
         <BarChart3 className="h-5 w-5 text-gray-600" />
-        <h3 className="font-semibold text-gray-900">나의 통계</h3>
+        <h3 className="font-semibold text-gray-900">{`나의 ${month}월 통계`}</h3>
       </div>
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-600">많이 이용한 업종</span>
-          <span className="text-sm font-semibold text-gray-900">{userStats.category}</span>
+          <span className="text-sm text-gray-600">{`최고의 카테고리`}</span>
+          <span className="text-sm font-semibold text-gray-900">{mostUsedCategoryName}</span>
         </div>
 
         <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-600">받은 혜택 개수</span>
-          <span className="text-sm font-semibold text-gray-900">{userStats.total}개</span>
+          <span className="text-sm text-gray-600">{`나를 사로잡은 브랜드`}</span>
+          <span className="text-sm font-semibold text-gray-900">{mostUsedBrandName}</span>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-600">{`내가 받은 혜택 수`}</span>
+          <span className="text-sm font-semibold text-gray-900">{monthlyUsedCount} 회</span>
         </div>
       </div>
     </Fragment>

--- a/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/NextStepBtn.tsx
@@ -36,7 +36,7 @@ const NextStepBtn = ({ currentStep, canProceed, setCurrentStep, info }: NextStep
       if (storeResult) {
         toast.info("가입을 환영합니다!");
         router.push("/home");
-      } else toast.error("오류가 발생했습니다. 잠시 후 다시 사용해 주세요.");
+      } else toast.error("오류가 발생했습니다. 잠시 후 다시 이용해 주세요.");
     }
   };
 

--- a/apps/user/src/service/user.ts
+++ b/apps/user/src/service/user.ts
@@ -1,4 +1,12 @@
-import { FeedbackForm, FeedbackRegistRes, InfoForm, LogoutRes, SetUserInfo, UserRole } from "@/types/profile";
+import {
+  FeedbackForm,
+  FeedbackRegistRes,
+  InfoForm,
+  LogoutRes,
+  SetUserInfo,
+  StaticsPreviewResponse,
+  UserRole,
+} from "@/types/profile";
 import api from "@api/http-commons";
 
 export const kakaoLogin = async (code: string): Promise<UserRole> => {
@@ -11,25 +19,30 @@ export const kakaoLogin = async (code: string): Promise<UserRole> => {
     throw new Error("응답이 정상적으로 오지 않음");
   }
   return response.data.data;
-}
+};
 
 export const getUserInfo = async () => {
   const { data } = await api.get("/api/users/userInfo");
   if (!data) throw new Error("유저 데이터가 존재하지 않음");
   return data;
-}
+};
 
 export const setUserInfo = async (params: InfoForm): Promise<SetUserInfo> => {
   const { data } = await api.put("api/users/userInfo", params);
   return data;
-}
+};
 
 export const logout = async (): Promise<LogoutRes> => {
   const { data } = await api.post("api/auth/logout");
   return data;
-}
+};
 
 export const registFeedback = async (params: FeedbackForm): Promise<FeedbackRegistRes> => {
   const { data } = await api.post("api/users/feedback", params);
   return data;
-}
+};
+
+export const fetchUserStatistics = async (): Promise<StaticsPreviewResponse> => {
+  const { data } = await api.get("/api/users/statistics/preview");
+  return data;
+};

--- a/apps/user/src/types/profile.ts
+++ b/apps/user/src/types/profile.ts
@@ -52,3 +52,52 @@ interface FeedbackId {
 export interface FeedbackRegistRes extends responseStatus {
   data: FeedbackId;
 }
+
+/** 사용자가 가장 많이 사용한 카테고리 */
+export interface CategoryStatistics {
+  categoryName: string;
+  usageCount: number;
+}
+
+/** 사용자가 가장 많이 사용한 브랜드 */
+export interface BrandStatistics {
+  brandName: string;
+  usageCount: number;
+}
+
+/** 사용자가 가장 많이 혜택을 사용한 날짜 요일, 시간 */
+export interface UsagePatternStatistics {
+  mostUsedDay: string;
+  mostUsedWeekday: string;
+  mostUsedTime: string;
+}
+/** 사용자가 전체 사용자중 몇% 정도의 혜택을 사용하는지 통계 */
+export interface UsageComparisonStatistics {
+  averageUsageCount: number;
+  userUsageCount: number;
+  averageDiffPercent: number;
+}
+
+/** 사용자가 가장 많은 혜택을 사용한 년 월 그리고 횟수 */
+export interface UsageMonthlyStatistics {
+  year: number;
+  month: number;
+  usageCount: number;
+}
+
+export interface StaticsData {
+  /** 사용자가 가장 많이 사용한 카테고리 */
+  categoryRankList: CategoryStatistics;
+  /** 사용자가 가장 많이 사용한 브랜드 */
+  brandRankList: BrandStatistics;
+  /** 사용자가 가장 많이 혜택을 사용한 날짜 요일, 시간 */
+  benefitUsagePattern: UsagePatternStatistics;
+  /** 사용자가 전체 사용자중 몇% 정도의 혜택을 사용하는지 통계 */
+  benefitUsageComparison: UsageComparisonStatistics;
+  /** 사용자가 가장 많은 혜택을 사용한 년 월 그리고 횟수 */
+  monthlyBenefitUsageList: UsageMonthlyStatistics;
+}
+
+export interface StaticsDataResponse extends responseStatus {
+  data: StaticsData;
+}

--- a/apps/user/src/types/profile.ts
+++ b/apps/user/src/types/profile.ts
@@ -65,11 +65,11 @@ export interface BrandStatistics {
   usageCount: number;
 }
 
-/** 사용자가 가장 많이 혜택을 사용한 날짜 요일, 시간 */
+/** 사용자가 가장 많이 혜택을 사용한 날짜 요일, 시간 (null 허용) */
 export interface UsagePatternStatistics {
-  mostUsedDay: string;
-  mostUsedWeekday: string;
-  mostUsedTime: string;
+  mostUsedDay: string | null;
+  mostUsedWeekday: string | null;
+  mostUsedTime: string | null;
 }
 /** 사용자가 전체 사용자중 몇% 정도의 혜택을 사용하는지 통계 */
 export interface UsageComparisonStatistics {
@@ -85,19 +85,29 @@ export interface UsageMonthlyStatistics {
   usageCount: number;
 }
 
-export interface StaticsData {
+export interface StaticsDetailData {
   /** 사용자가 가장 많이 사용한 카테고리 */
-  categoryRankList: CategoryStatistics;
+  categoryRankList: CategoryStatistics[];
   /** 사용자가 가장 많이 사용한 브랜드 */
-  brandRankList: BrandStatistics;
+  brandRankList: BrandStatistics[];
   /** 사용자가 가장 많이 혜택을 사용한 날짜 요일, 시간 */
   benefitUsagePattern: UsagePatternStatistics;
   /** 사용자가 전체 사용자중 몇% 정도의 혜택을 사용하는지 통계 */
   benefitUsageComparison: UsageComparisonStatistics;
   /** 사용자가 가장 많은 혜택을 사용한 년 월 그리고 횟수 */
-  monthlyBenefitUsageList: UsageMonthlyStatistics;
+  monthlyBenefitUsageList: UsageMonthlyStatistics[];
 }
 
-export interface StaticsDataResponse extends responseStatus {
-  data: StaticsData;
+export interface StaticsDetailDataResponse extends responseStatus {
+  data: StaticsDetailData;
+}
+
+export interface StaticsPreviewData {
+  mostUsedCategoryName: string | null;
+  mostUsedBrandName: string | null;
+  monthlyUsedCount: number;
+}
+
+export interface StaticsPreviewResponse extends responseStatus {
+  data: StaticsPreviewData;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #75 

## 📝작업 내용

사용자의 혜택 이용 통계를 출력한다.

통계는 월별로 집계된다.

## 📷스크린샷 (선택)

<img width="391" height="183" alt="image" src="https://github.com/user-attachments/assets/34179fc7-08b6-4d51-9fe1-feb2cc033e41" />

<img width="392" height="202" alt="image" src="https://github.com/user-attachments/assets/7bf6bdac-f19d-4ea4-9f9c-3587c718c101" />

## 💬리뷰 요구사항(선택)

타입에 detailestatics가 있을 텐데 현재 api는 존재하지만 통계 오류와 개발 시간 때문에 백엔드 개발자분과 서로 상호 협의 하에 응답값을 조정하였습니다. 
detail 통계는 향후 시간이 된다면 사용할 수 있을것 같아서 남겨뒀습니다.