### PR TITLE
[FIX] UBLE-88 지도 카테고리별 api 요청 타입 설정

### DIFF
--- a/apps/user/src/hooks/map/useStorePins.ts
+++ b/apps/user/src/hooks/map/useStorePins.ts
@@ -7,6 +7,7 @@ import { useMapStore } from "@/store/useMapStore";
 import { Category } from "@/types/category";
 import { Pin } from "@/app/(main)/map/components/NaverMap";
 import { DEFAULT_LOCATION } from "@/types/constants";
+import { getCurrentSeason } from "@/utils/season";
 
 export function useStorePins(baseLocation: Coordinates | null, selectedCategory: Category) {
   const selectedPlaceId = useMapStore((s) => s.selectedPlaceId);
@@ -21,8 +22,16 @@ export function useStorePins(baseLocation: Coordinates | null, selectedCategory:
         latitude: baseLocation[1],
         longitude: baseLocation[0],
         distance: 500, //TODO: distance zoom 변환 설정
-        ...(typeof selectedCategory.categoryId === "number" &&
-          selectedCategory.categoryId !== 0 && { categoryId: selectedCategory.categoryId }),
+        ...(typeof selectedCategory.categoryId === "number" && selectedCategory.categoryId !== 0
+          ? { categoryId: selectedCategory.categoryId }
+          : {}),
+        season: selectedCategory.categoryId === "SEASON" ? getCurrentSeason() : undefined,
+        type:
+          selectedCategory.categoryId === "VIP"
+            ? "VIP"
+            : selectedCategory.categoryId === "LOCAL"
+              ? "LOCAL"
+              : undefined,
       });
 
       const storePins: Pin[] = stores.map((store) => ({


### PR DESCRIPTION
## #️⃣연관된 이슈

#87 

## 📝작업 내용

season, vip, local 카테고리 선택시 계절 hook 호출하여 season 혹은 type 설정하여 api 요청

## 📷스크린샷 (선택)
![화면 기록 2025-07-25 오전 3 43 39](https://github.com/user-attachments/assets/45fe6fd8-af6e-49c0-8f20-27b47befdc60)


## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매장 목록 필터에 시즌 및 타입(VIP, LOCAL) 기반 필터링이 추가되어 더욱 다양한 조건으로 매장 검색이 가능합니다.  
* **개선 사항**
  * 카테고리 선택 시 숫자 ID뿐만 아니라, 시즌 및 타입별 필터가 적용되어 검색 결과의 정확도가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->