### PR TITLE
[FIX] UBLE-96 피드백 내용 입력 시 줄바꿈이 안되고 UI가 망가지는 현상, UI가 늘어나는 현상 수정

### DIFF
--- a/apps/user/src/components/modal/FeedbackModal.tsx
+++ b/apps/user/src/components/modal/FeedbackModal.tsx
@@ -68,9 +68,10 @@ const FeedbackModal = () => {
             <Label htmlFor="feedback-title">제목</Label>
             <Input
               id="feedback-title"
+              maxLength={25}
               value={formData.title}
               onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
-              placeholder="피드백 제목을 입력해주세요"
+              placeholder="피드백 제목을 입력해 주세요 (최대 25자)"
               className="focus-visible:ring-action-green h-11 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
             />
           </div>
@@ -79,11 +80,15 @@ const FeedbackModal = () => {
           <div className="space-y-2">
             <Label htmlFor="feedback-content">내용</Label>
             <Textarea
+              maxLength={200}
               id="feedback-content"
               value={formData.content}
-              onChange={(e) => setFormData((prev) => ({ ...prev, content: e.target.value }))}
-              placeholder="자세한 내용을 입력해주세요"
-              className="min-h-[120px] resize-none"
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v.length <= 200) setFormData((p) => ({ ...p, content: v })); // ← 길이 검증 로직
+              }}
+              placeholder="자세한 내용을 입력해주세요 (최대 200자)"
+              className="h-32 min-h-[120px] resize-none overflow-auto whitespace-pre-wrap break-all"
             />
           </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #97 

## 📝작업 내용

피드백 제목 입력이 25자로 제한됩니다.

피드백 내용 입력이 200자로 제한됩니다.

피드백 내용에 과도하게 많은 영문 문자 입력 시 더이상 UI가 오른쪽으로 늘어나지 않습니다.

피드백 내용에 과도하게 많은 한글 문자 입력 시 더이상 UI가 아래로 늘어나지 않습니다.

사용자가 입력 영역 이상으로 많은 글을 썼다면 영역 내부에서 스크롤하여 내용을 확인할 수 있도록 변경하였습니다.

## 📷스크린샷 (선택)

<img width="625" height="916" alt="image" src="https://github.com/user-attachments/assets/57071163-09df-44cd-975c-ce756c2f949b" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?