### PR TITLE
[FEAT] UBLE-99 지도 bounds 기반 매장 조회 로직 반영 및 유틸 분리

### DIFF
--- a/apps/user/src/app/(main)/map/components/MapContainer.tsx
+++ b/apps/user/src/app/(main)/map/components/MapContainer.tsx
@@ -23,6 +23,10 @@ import { Pin } from "@/app/(main)/map/components/NaverMap";
 
 import { toast } from "sonner";
 
+/**
+ * 지도 컨테이너 컴포넌트
+ * @returns 지도 컨테이너 컴포넌트
+ */
 export default function MapContainer() {
   const [selectedCategory, setSelectedCategory] = useState<Category>(ALL_CATEGORY);
   const [isOpen, setIsOpen] = useState(false);
@@ -81,7 +85,7 @@ export default function MapContainer() {
   };
 
   return (
-    <div className="relative h-screen w-full">
+    <div className="relative h-full w-full">
       <MapWithBaseLocation
         zoom={15}
         selectedCategory={selectedCategory}

--- a/apps/user/src/app/(main)/map/components/MapWithBaseLocation.tsx
+++ b/apps/user/src/app/(main)/map/components/MapWithBaseLocation.tsx
@@ -1,55 +1,174 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState, useCallback, useRef } from "react";
+import { useDebouncedCallback } from "use-debounce";
 import { useCurrentLocation } from "@/hooks/map/useCurrentLocation";
 import NaverMap, { Pin } from "@/app/(main)/map/components/NaverMap";
 import { Category } from "@/types/category";
 import { useBaseLocation } from "@/hooks/map/useBaseLocation";
-import { useStorePins } from "@/hooks/map/useStorePins";
 import { DEFAULT_LOCATION } from "@/types/constants";
-import { StoreSummary, StoreDetail } from "@/types/store";
-import { useMapStore } from "@/store/useMapStore";
+import { Coordinates } from "@/types/map";
+import { Button } from "@workspace/ui/components/button";
+import { fetchStorePins } from "@/utils/fetchStorePins";
+import { createBoundsFromCenterAndZoom } from "@/utils/mapBounds";
 
 interface MapWithBaseLocationProps {
-  zoom: number;
   selectedCategory: Category;
   onPinClick: (pin: Pin) => void;
+  zoom?: number;
 }
 
+/**
+ * 현재 위치를 기준으로 지도를 표시하는 컴포넌트
+ * @param zoom 지도 줌 레벨
+ * @param selectedCategory 선택된 카테고리
+ * @param onPinClick 마커 클릭 시 호출되는 함수
+ * @returns 지도 컴포넌트
+ */
 export default function MapWithBaseLocation({
-  zoom,
   selectedCategory,
   onPinClick,
+  zoom = 15,
 }: MapWithBaseLocationProps) {
   const { location: currentLocation, getCurrentLocation } = useCurrentLocation();
+  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
     getCurrentLocation();
   }, [getCurrentLocation]);
 
-  const places = useMapStore((s) => s.myPlaces);
-  const selectedPlaceId = useMapStore((s) => s.selectedPlaceId);
-  // 선택된 장소만 baseLocation으로 사용
-  const selectedPlace = places.find((p) => p.id === selectedPlaceId);
-  // fallback: currentLocation or default
-  const baseLocation = selectedPlace
-    ? selectedPlace.coordinates
-    : (currentLocation ?? DEFAULT_LOCATION);
+  const baseLocation = useBaseLocation(currentLocation ?? DEFAULT_LOCATION);
 
-  const storePins = useStorePins(baseLocation, selectedCategory);
-  const pins = useMemo(
+  // 지도 bounds/center 추적
+  const [mapBounds, setMapBounds] = useState<naver.maps.LatLngBounds | null>(null);
+  const [mapCenter, setMapCenter] = useState<Coordinates>(baseLocation);
+  const [showSearchBtn, setShowSearchBtn] = useState(false);
+  const [pins, setPins] = useState<Pin[]>([]);
+  const lastBaseLocationRef = useRef<Coordinates>(baseLocation);
+
+  const fetchPins = useCallback(
+    async (center: Coordinates, bounds: naver.maps.LatLngBounds, category?: Category) => {
+      try {
+        const pins = await fetchStorePins(
+          center,
+          bounds,
+          category ?? selectedCategory,
+          baseLocation
+        );
+        setPins(pins);
+      } catch (error) {
+        setPins([]);
+      }
+      setShowSearchBtn(false);
+    },
+    [baseLocation, selectedCategory]
+  );
+
+  // 초기화: currentLocation이 로드되면 첫 번째 fetchPins 실행
+  useEffect(() => {
+    if (currentLocation && !isInitialized) {
+      const initialBounds = createBoundsFromCenterAndZoom(currentLocation, zoom);
+      if (initialBounds) {
+        setMapBounds(initialBounds);
+        fetchPins(currentLocation, initialBounds);
+        lastBaseLocationRef.current = currentLocation;
+        setMapCenter(currentLocation);
+        setIsInitialized(true);
+      }
+    }
+  }, [currentLocation, isInitialized, fetchPins]);
+
+  // baseLocation이 바뀌면 즉시 fetchPins (내장소/현위치 변경 시)
+  useEffect(() => {
+    if (
+      isInitialized &&
+      (baseLocation[0] !== lastBaseLocationRef.current[0] ||
+        baseLocation[1] !== lastBaseLocationRef.current[1])
+    ) {
+      setMapCenter(baseLocation); // 지도 중심은 baseLocation으로 이동
+      lastBaseLocationRef.current = baseLocation;
+
+      // 새로운 baseLocation에 맞는 bounds 생성
+      const newBounds = createBoundsFromCenterAndZoom(baseLocation, zoom);
+      if (newBounds) {
+        setMapBounds(newBounds);
+        fetchPins(baseLocation, newBounds); // 새로운 bounds 기준으로 fetch
+        setShowSearchBtn(false);
+      }
+    }
+  }, [baseLocation, isInitialized, fetchPins]);
+
+  // 카테고리 변경시 현재 위치에서 fetchPins
+  useEffect(() => {
+    if (isInitialized && mapBounds && mapCenter) {
+      fetchPins(mapCenter, mapBounds, selectedCategory);
+    }
+  }, [selectedCategory.categoryId]);
+
+  // 지도 bounds/center 변경 시 (드래그/줌)
+  const handleBoundsChange = useDebouncedCallback(
+    (bounds: naver.maps.LatLngBounds, center: Coordinates) => {
+      setMapBounds(bounds);
+      setMapCenter(center);
+
+      // baseLocation과 center가 다르고, 사용자가 실제로 지도를 이동했을 때만 버튼 노출
+      const distance = Math.sqrt(
+        Math.pow(center[0] - baseLocation[0], 2) + Math.pow(center[1] - baseLocation[1], 2)
+      );
+      // 일정 거리 이상 이동했을 때만 버튼 표시 (약 100m)
+      if (distance > 0.001) {
+        setShowSearchBtn(true);
+      } else {
+        setShowSearchBtn(false);
+      }
+    },
+    300 // 300ms 디바운싱
+  );
+
+  // 버튼 클릭 시 현재 bounds/center로 fetchPins
+  const handleSearchHere = () => {
+    if (mapBounds && mapCenter) {
+      fetchPins(mapCenter, mapBounds, selectedCategory);
+    }
+  };
+
+  const pinsWithClick = useMemo(
     () =>
-      storePins.map((pin) => ({
+      pins.map((pin) => ({
         ...pin,
         onClick: () => {
-          onPinClick(pin); // TODO: coords 수정
+          onPinClick(pin);
         },
       })),
-    [storePins, onPinClick]
+    [pins, onPinClick]
   );
+
+  // currentLocation이 로드될 때까지 로딩 표시
+  if (!currentLocation) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="text-gray-500">현재 위치를 불러오는 중...</div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex h-full w-full">
-      {baseLocation && <NaverMap loc={baseLocation} zoom={zoom} pins={pins} />}
+    <div className="relative flex h-full w-full">
+      <NaverMap
+        loc={mapCenter}
+        zoom={zoom}
+        pins={pinsWithClick}
+        onBoundsChange={handleBoundsChange}
+      />
+      {showSearchBtn && (
+        <Button
+          className="absolute bottom-5 left-1/2 z-20 -translate-x-1/2 rounded-full"
+          variant="filter_select"
+          onClick={handleSearchHere}
+        >
+          현재 위치에서 검색
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/user/src/app/(main)/map/layout.tsx
+++ b/apps/user/src/app/(main)/map/layout.tsx
@@ -3,13 +3,22 @@ import Script from "next/script";
 export default function MapLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
+      {/* 네이버 지도 및 클러스터링 스크립트 */}
       <Script
         strategy="afterInteractive"
         type="text/javascript"
         src={`https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${process.env.NEXT_PUBLIC_MAP_CLIENT_ID}&submodules=geocoder`}
       />
       <Script strategy="afterInteractive" src="/MarkerClustering.js" />
-      {children}
+
+      <main
+        style={{
+          height: "calc(100vh - 60px - 72px)",
+          overflow: "hidden",
+        }}
+      >
+        {children}
+      </main>
     </>
   );
 }

--- a/apps/user/src/service/store.ts
+++ b/apps/user/src/service/store.ts
@@ -9,9 +9,10 @@ import {
 } from "@/types/store";
 
 interface GetNearbyStoresParams {
-  latitude: number;
-  longitude: number;
-  distance: number;
+  swLat: number;
+  swLng: number;
+  neLat: number;
+  neLng: number;
   categoryId?: number;
   brandId?: number;
   season?: string;

--- a/apps/user/src/utils/fetchStorePins.ts
+++ b/apps/user/src/utils/fetchStorePins.ts
@@ -18,46 +18,54 @@ export async function fetchStorePins(
   category: Category,
   baseLocation?: Coordinates
 ): Promise<Pin[]> {
-  const ne = bounds.getNE();
-  const sw = bounds.getSW();
+  try {
+    const ne = bounds.getNE();
+    const sw = bounds.getSW();
 
-  const stores = await getNearbyStores({
-    swLat: sw.lat(),
-    swLng: sw.lng(),
-    neLat: ne.lat(),
-    neLng: ne.lng(),
-    ...(typeof category.categoryId === "number" && category.categoryId !== 0
-      ? { categoryId: category.categoryId }
-      : {}),
-    season: category.categoryId === "SEASON" ? getCurrentSeason() : undefined,
-    type:
-      category.categoryId === "VIP" ? "VIP" : category.categoryId === "LOCAL" ? "LOCAL" : undefined,
-  });
+    const stores = await getNearbyStores({
+      swLat: sw.lat(),
+      swLng: sw.lng(),
+      neLat: ne.lat(),
+      neLng: ne.lng(),
+      ...(typeof category.categoryId === "number" && category.categoryId !== 0
+        ? { categoryId: category.categoryId }
+        : {}),
+      season: category.categoryId === "SEASON" ? getCurrentSeason() : undefined,
+      type:
+        category.categoryId === "VIP"
+          ? "VIP"
+          : category.categoryId === "LOCAL"
+            ? "LOCAL"
+            : undefined,
+    });
 
-  const storePins: Pin[] = stores.map((store) => ({
-    id: store.storeId,
-    coords: [store.longitude, store.latitude],
-    name: store.storeName,
-    category: store.category,
-    type: "store",
-  }));
+    const storePins: Pin[] = stores.map((store) => ({
+      id: store.storeId,
+      coords: [store.longitude, store.latitude],
+      name: store.storeName,
+      category: store.category,
+      type: "store",
+    }));
 
-  const shouldShowCurrentLocation =
-    baseLocation &&
-    Math.abs(center[0] - baseLocation[0]) < 0.0001 &&
-    Math.abs(center[1] - baseLocation[1]) < 0.0001;
+    const shouldShowCurrentLocation =
+      baseLocation &&
+      Math.abs(center[0] - baseLocation[0]) < 0.0001 &&
+      Math.abs(center[1] - baseLocation[1]) < 0.0001;
 
-  if (shouldShowCurrentLocation) {
-    return [
-      {
-        id: -1,
-        coords: center,
-        name: "현위치",
-        type: "current",
-      },
-      ...storePins,
-    ];
+    if (shouldShowCurrentLocation) {
+      return [
+        {
+          id: -1,
+          coords: center,
+          name: "현위치",
+          type: "current",
+        },
+        ...storePins,
+      ];
+    }
+
+    return storePins;
+  } catch (error) {
+    return [];
   }
-
-  return storePins;
 }

--- a/apps/user/src/utils/fetchStorePins.ts
+++ b/apps/user/src/utils/fetchStorePins.ts
@@ -1,0 +1,63 @@
+import { Coordinates } from "@/types/map";
+import { getNearbyStores } from "@/service/store";
+import { Category } from "@/types/category";
+import { getCurrentSeason } from "@/utils/season";
+import { Pin } from "@/app/(main)/map/components/NaverMap";
+
+/**
+ * 지도에 표시할 매장 데이터를 조회하는 함수
+ * @param center 지도 중심 좌표
+ * @param bounds 지도 사각형 영역
+ * @param category 선택된 카테고리
+ * @param baseLocation 기반 위치
+ * @returns 매장 marker 데이터 배열
+ */
+export async function fetchStorePins(
+  center: Coordinates,
+  bounds: naver.maps.LatLngBounds,
+  category: Category,
+  baseLocation?: Coordinates
+): Promise<Pin[]> {
+  const ne = bounds.getNE();
+  const sw = bounds.getSW();
+
+  const stores = await getNearbyStores({
+    swLat: sw.lat(),
+    swLng: sw.lng(),
+    neLat: ne.lat(),
+    neLng: ne.lng(),
+    ...(typeof category.categoryId === "number" && category.categoryId !== 0
+      ? { categoryId: category.categoryId }
+      : {}),
+    season: category.categoryId === "SEASON" ? getCurrentSeason() : undefined,
+    type:
+      category.categoryId === "VIP" ? "VIP" : category.categoryId === "LOCAL" ? "LOCAL" : undefined,
+  });
+
+  const storePins: Pin[] = stores.map((store) => ({
+    id: store.storeId,
+    coords: [store.longitude, store.latitude],
+    name: store.storeName,
+    category: store.category,
+    type: "store",
+  }));
+
+  const shouldShowCurrentLocation =
+    baseLocation &&
+    Math.abs(center[0] - baseLocation[0]) < 0.0001 &&
+    Math.abs(center[1] - baseLocation[1]) < 0.0001;
+
+  if (shouldShowCurrentLocation) {
+    return [
+      {
+        id: -1,
+        coords: center,
+        name: "현위치",
+        type: "current",
+      },
+      ...storePins,
+    ];
+  }
+
+  return storePins;
+}

--- a/apps/user/src/utils/mapBounds.ts
+++ b/apps/user/src/utils/mapBounds.ts
@@ -1,0 +1,24 @@
+import { Coordinates } from "@/types/map";
+
+/**
+ * 지도 중심 좌표를 기반으로 지도 사각형 영역을 생성하는 함수
+ * @param center 지도 중심 좌표
+ * @returns 지도 사각형 영역
+ */
+export function createBoundsFromCenterAndZoom(
+  center: Coordinates,
+  zoom: number
+): naver.maps.LatLngBounds | null {
+  if (typeof window === "undefined" || !window.naver?.maps) return null;
+
+  const zoomFactor = Math.pow(2, 15 - zoom);
+  const latDelta = 0.01 / zoomFactor;
+  const lngDelta = 0.01 / zoomFactor;
+
+  const bounds = new window.naver.maps.LatLngBounds(
+    new window.naver.maps.LatLng(center[1] - latDelta, center[0] - lngDelta),
+    new window.naver.maps.LatLng(center[1] + latDelta, center[0] + lngDelta)
+  );
+
+  return bounds;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#100 

## 📝작업 내용

- `bounds` 계산 유틸 함수 생성
- `NaverMap.tsx` 에 bounds 변경 감지를 위한 onBoundsChange 핸들러 추가 및 pin 없을 경우 로직 추가
- 주변 매장 조회 fetch 로직을 fetchStorePins 유틸로 분리
- 스크롤 없는 레이아웃 적용을 위해 `app/(main)/map/layout.tsx`에서 main 스타일 조정



## 📷스크린샷 (선택)
![화면 기록 2025-07-27 오후 2 55 51_2](https://github.com/user-attachments/assets/db62f623-8487-49d1-9002-56e33dfc1765)

![화면 기록 2025-07-27 오후 2 55 51_3](https://github.com/user-attachments/assets/49b875c0-e5ce-4bcd-939b-7688bf55f48b)

## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 지도에서 현재 보이는 영역을 기반으로 매장 핀을 동적으로 불러오고, 지도를 이동하면 "이 위치에서 검색" 버튼이 표시됩니다.
  * 지도 중심 및 범위 변경 시 외부에서 콜백을 받을 수 있습니다.
  * 새로운 유틸리티 함수로 중심 좌표와 줌 레벨로부터 지도 범위를 생성할 수 있습니다.

* **개선 사항**
  * 지도 컨테이너의 높이 스타일이 전체 화면에서 부모 컨테이너 기준으로 변경되었습니다.
  * 지도 페이지 레이아웃이 `<main>` 태그로 감싸지고, 높이 및 오버플로우 스타일이 조정되었습니다.
  * 매장 검색 시 중심 좌표와 거리 대신, 지도 영역의 남서/북동 좌표를 사용하도록 변경되었습니다.

* **버그 수정**
  * 핀이 없거나 비어 있을 때 지도 마커가 올바르게 제거됩니다.

* **문서화**
  * 주요 컴포넌트에 JSDoc 주석이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->