### PR TITLE
[FIX] UBLE-100 즐겨찾기 동기화

### DIFF
--- a/apps/user/src/app/(main)/favorites/components/FavoriteBrandSection.tsx
+++ b/apps/user/src/app/(main)/favorites/components/FavoriteBrandSection.tsx
@@ -8,8 +8,10 @@ import useInfiniteScroll from "@/hooks/useInfiniteScroll";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { FetchFavoritesParams, fetchFavoritesQuery } from "@/service/favorites";
 import useUserStore from "@/store/useUserStore";
+import { useRouter } from "next/navigation";
 
 export default function FavoriteBrandSection() {
+  const router = useRouter();
   const user = useUserStore((s) => s.user);
 
   // 즐겨찾기 데이터 받아오기
@@ -64,7 +66,12 @@ export default function FavoriteBrandSection() {
     <div>
       <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {favoriteBrands.map((brand: BrandContent) => (
-          <DynamicCard key={brand.brandId} data={brand} variant="horizontal" />
+          <DynamicCard
+            key={brand.brandId}
+            data={brand}
+            variant="horizontal"
+            onClick={() => router.push(`/partnerships/${brand.brandId}`)}
+          />
         ))}
       </div>
       <div ref={loadMoreRef} className="h-1" />

--- a/apps/user/src/app/(main)/favorites/components/FavoriteBrandSection.tsx
+++ b/apps/user/src/app/(main)/favorites/components/FavoriteBrandSection.tsx
@@ -27,7 +27,7 @@ export default function FavoriteBrandSection() {
       lastPage.hasNext ? lastPage.lastCursorId : undefined,
     // enabled: Boolean(user),
     refetchOnMount: true,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
     initialPageParam: undefined,
   });
 

--- a/apps/user/src/app/(main)/home/components/EntireSection.tsx
+++ b/apps/user/src/app/(main)/home/components/EntireSection.tsx
@@ -46,8 +46,8 @@ export default function EntireSection() {
     getNextPageParam: (lastPage: BrandListData) =>
       lastPage.hasNext ? lastPage.lastCursorId : undefined,
     staleTime: 1000 * 60 * 5,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
     initialPageParam: undefined,
   });
 

--- a/apps/user/src/components/FavoriteBtn.tsx
+++ b/apps/user/src/components/FavoriteBtn.tsx
@@ -121,7 +121,6 @@ const FavoriteBtn = ({ brandId, bookmarked = false, variant }: FavoriteBtnProps)
       invalidate();
     },
     onError: (error: Error) => {
-      console.log(error);
       setIsLiked((prev) => !prev); // 실패했으면 상태 복구
       toast.error("오류가 발생했습니다. 잠시 후 다시 이용해 주세요.");
     },

--- a/apps/user/src/components/FavoriteBtn.tsx
+++ b/apps/user/src/components/FavoriteBtn.tsx
@@ -95,22 +95,24 @@ const FavoriteBtn = ({ brandId, bookmarked = false, variant }: FavoriteBtnProps)
         // cursor param 꺼내기
         const cursor = pageParams[pageIndex];
         const params = fullKey[1] as FetchBrandsParams; // ["brands", params]
+        try {
+          // 해당 페이지 하나만 재요청
+          const updatedPage = await fetchBrands({
+            ...params,
+            lastBrandId: cursor,
+          });
 
-        // 해당 페이지 하나만 재요청
-        const updatedPage = await fetchBrands({
-          ...params,
-          lastBrandId: cursor,
-        });
-
-        // 캐시에 그 페이지만 대체
-        queryClient.setQueryData(fullKey, (old: any) => {
-          if (!old || !Array.isArray(old.pages)) return old;
-          return {
-            ...old,
-            pages: old.pages.map((pg: any, i: number) => (i === pageIndex ? updatedPage : pg)),
-          };
-        });
-
+          // 캐시에 그 페이지만 대체
+          queryClient.setQueryData(fullKey, (old: any) => {
+            if (!old || !Array.isArray(old.pages)) return old;
+            return {
+              ...old,
+              pages: old.pages.map((pg: any, i: number) => (i === pageIndex ? updatedPage : pg)),
+            };
+          });
+        } catch (err) {
+          toast.error("오류가 발생했습니다. 잠시 후 다시 이용해 주세요.");
+        }
         // 하나만 바꾸고 루프 종료
         break;
       }

--- a/apps/user/src/components/FavoriteBtn.tsx
+++ b/apps/user/src/components/FavoriteBtn.tsx
@@ -4,45 +4,132 @@ import { Heart } from "lucide-react";
 import classNames from "classnames";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteFavoriteMutation, postFavoritesMutation } from "@/service/favorites";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { BrandContent, BrandListData, FetchBrandsParams } from "@/types/brand";
+import { fetchBrands } from "@/service/brand";
 
 interface FavoriteBtnProps {
-  /** brandId를 통해 향후 서버에 즐겨찾기 등록 요청 */
   brandId: number;
   bookmarked?: boolean;
   variant: string;
 }
-const FavoriteBtn = ({ brandId, bookmarked, variant }: FavoriteBtnProps) => {
+const FavoriteBtn = ({ brandId, bookmarked = false, variant }: FavoriteBtnProps) => {
   const queryClient = useQueryClient();
-  const [isLiked, setIsLiked] = useState(bookmarked ?? false);
+  const [isLiked, setIsLiked] = useState(bookmarked);
+  useEffect(() => {
+    setIsLiked(bookmarked);
+  }, [bookmarked]);
 
+  /** 캐시 무효화, useQuery를 사용하는 쿼리들 업데이트 */
   const invalidate = () => {
-    queryClient.invalidateQueries({ queryKey: ["favoriteBrands"] });
-    queryClient.invalidateQueries({ queryKey: ["brands"] });
-    queryClient.invalidateQueries({ queryKey: ["storeDetail", brandId] });
+    ["timeRecommend", "ageRecommend", "favoriteBrands"].forEach((k) =>
+      queryClient.invalidateQueries({ queryKey: [k] })
+    );
+    queryClient.invalidateQueries({ queryKey: ["brandDetail", brandId.toString()] });
+    queryClient.invalidateQueries({ queryKey: ["storeDetail", brandId.toString()] });
   };
 
   const { mutate, isPending } = useMutation({
-    mutationFn: async () => {
-      if (isLiked) {
-        await deleteFavoriteMutation({ brandId });
-        setIsLiked(false);
-      } else {
-        await postFavoritesMutation({ brandId });
-        setIsLiked(true);
-      }
+    mutationFn: (newIsLiked: boolean) =>
+      newIsLiked ? postFavoritesMutation({ brandId }) : deleteFavoriteMutation({ brandId }),
+    onMutate: async (newState: boolean) => {
+      // InfiniteQuery에 먼저 낙관적 업데이트
+      const infiniteKeys = ([["brands"], ["storeDetail", brandId]] as const).map((k) => ({
+        queryKey: k,
+      }));
+
+      // 쿼리 취소 & 백업
+      await Promise.all(
+        infiniteKeys.map(({ queryKey }) => queryClient.cancelQueries({ queryKey }))
+      );
+      const prev = infiniteKeys.map(({ queryKey }) => ({
+        queryKey,
+        data: queryClient.getQueryData(queryKey),
+      }));
+
+      // 캐시 토글
+      infiniteKeys.forEach(({ queryKey }) => {
+        queryClient.setQueryData(queryKey, (old: any) =>
+          old
+            ? {
+                ...old,
+                pages: old.pages.map((page: any) => ({
+                  ...page,
+                  content: page.content.map((item: any) =>
+                    item.brandId === brandId ? { ...item, isBookmarked: newState } : item
+                  ),
+                })),
+              }
+            : old
+        );
+      });
+
+      return { prev };
     },
-    onSuccess: invalidate,
+    onSuccess: async (newState) => {
+      // 1) "brands" 로 시작하는 모든 infiniteQuery 키만 골라서
+      const brandQueries = queryClient.getQueriesData<{
+        pages: BrandListData[];
+        pageParams: any[];
+      }>({
+        queryKey: ["brands"], // prefix로 걸러내고
+        exact: false, // 정확히 일치 말고 시작만 일치
+      });
+
+      for (const [fullKey, data] of brandQueries) {
+        // 2) 타입 가드: data.pages 가 배열인지 확인
+        if (!data || typeof data !== "object" || !Array.isArray((data as any).pages)) {
+          continue;
+        }
+
+        const pages = (data as any).pages as BrandListData[];
+        const pageParams = (data as any).pageParams as any[];
+
+        // 어느 페이지에 이 brandId가 있는지 찾기
+        const pageIndex = pages.findIndex((page) =>
+          page.content.some((item) => item.brandId === brandId)
+        );
+        if (pageIndex === -1) continue;
+
+        // cursor param 꺼내기
+        const cursor = pageParams[pageIndex];
+        const params = fullKey[1] as FetchBrandsParams; // ["brands", params]
+
+        // 해당 페이지 하나만 재요청
+        const updatedPage = await fetchBrands({
+          ...params,
+          lastBrandId: cursor,
+        });
+
+        // 캐시에 그 페이지만 대체
+        queryClient.setQueryData(fullKey, (old: any) => {
+          if (!old || !Array.isArray(old.pages)) return old;
+          return {
+            ...old,
+            pages: old.pages.map((pg: any, i: number) => (i === pageIndex ? updatedPage : pg)),
+          };
+        });
+
+        // 하나만 바꾸고 루프 종료
+        break;
+      }
+
+      // 그 외 invalidate
+      invalidate();
+    },
     onError: (error: Error) => {
+      console.log(error);
       setIsLiked((prev) => !prev); // 실패했으면 상태 복구
       toast.error("오류가 발생했습니다. 잠시 후 다시 이용해 주세요.");
     },
+    onSettled: invalidate,
   });
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    mutate();
+    const newState = !isLiked;
+    mutate(newState);
   };
 
   return (

--- a/apps/user/src/components/common/Footer.tsx
+++ b/apps/user/src/components/common/Footer.tsx
@@ -20,7 +20,7 @@ export default function Footer() {
         {navItems.map(({ path, icon: Icon, label }) => (
           <button
             key={path}
-            onClick={() => router.push(path)}
+            onClick={() => router.replace(path)}
             className={`flex flex-1 flex-col items-center py-2 transition-colors ${
               pathname === path ? "text-gray-900" : "text-gray-400"
             }`}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #102 

## 📝작업 내용

즐겨찾기 등록 시 즐겨찾기 아이콘이 포함된 모든 UI가 동기화 되지 않는 문제 수정

전체 제휴처 목록에서 즐겨찾기를 수행할 경우 낙관적 업데이트 수행

즐겨찾기 요청 성공 시 해당 카드만 다시 업데이트하도록 수정

하단 네비게이션 바 클릭 시 replace로 이동하도록 리팩토링

즐겨찾기 목록에서 즐겨찾기 제휴처 클릭 시 상세 페이지로 이동하도록 구현

## 📷스크린샷 (선택)

![localhost_3000_kakaocallback_code=eIw_nijno7YdgR-StAO90Eazvbq38NdJXbnXX9iWyg7UHnJR6hjIBgAAAAQKDSBaAAABmE6UAfOGtS2__sNdBQ - Chrome 2025-07-28 10-17-55](https://github.com/user-attachments/assets/30044919-ef98-4da1-928f-9a69f062093b)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 즐겨찾기 브랜드 카드를 클릭하면 해당 브랜드의 상세 파트너십 페이지로 이동할 수 있습니다.

* **버그 수정**
  * 즐겨찾기 버튼 클릭 시 더욱 부드러운 UI 반영 및 캐시 동기화가 개선되었습니다.

* **기능 개선**
  * 즐겨찾기 및 홈 섹션 데이터가 창 포커스 복귀 또는 컴포넌트 마운트 시 자동으로 새로고침됩니다.
  * 푸터 내비게이션 버튼 클릭 시 브라우저 히스토리 관리 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->