### PR TITLE
[FEAT] UBLE-110 매장 검색 요청 파라미터 추가 적용

### DIFF
--- a/apps/user/src/app/(main)/map/components/MapSearchSection.tsx
+++ b/apps/user/src/app/(main)/map/components/MapSearchSection.tsx
@@ -8,7 +8,7 @@ const MapSearchSection = () => {
   const [searchQuery, setSearchQuery] = useState("");
 
   const handleInputClick = () => {
-    // router.push("/search");
+    router.push("/search");
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/user/src/app/(main)/map/components/MapWithBaseLocation.tsx
+++ b/apps/user/src/app/(main)/map/components/MapWithBaseLocation.tsx
@@ -12,7 +12,7 @@ import { Button } from "@workspace/ui/components/button";
 import { fetchStorePins } from "@/utils/fetchStorePins";
 import { createBoundsFromCenterAndZoom } from "@/utils/mapBounds";
 
-export const DEFAULT_ZOOM_LEVEL_LEVEL = 15;
+export const DEFAULT_ZOOM_LEVEL = 15;
 
 interface MapWithBaseLocationProps {
   selectedCategory: Category;
@@ -51,7 +51,7 @@ export default function MapWithBaseLocation({
   // 지도 bounds/center 추적
   const [mapBounds, setMapBounds] = useState<naver.maps.LatLngBounds | null>(null);
   const [mapCenter, setMapCenter] = useState<Coordinates>(baseLocation);
-  const [mapZoomLevel, setMapZoomLevel] = useState<number>(DEFAULT_ZOOM_LEVEL_LEVEL);
+  const [mapZoomLevel, setMapZoomLevel] = useState<number>(DEFAULT_ZOOM_LEVEL);
   const [showSearchBtn, setShowSearchBtn] = useState(false);
   const [pins, setPins] = useState<Pin[]>([]);
   const [isExitingSearchMode, setIsExitingSearchMode] = useState(false);
@@ -99,13 +99,10 @@ export default function MapWithBaseLocation({
   // 초기화: currentLocation이 로드되면 첫 번째 fetchPins 실행
   useEffect(() => {
     if (currentLocation && !isInitialized) {
-      const initialBounds = createBoundsFromCenterAndZoom(
-        currentLocation,
-        DEFAULT_ZOOM_LEVEL_LEVEL
-      );
+      const initialBounds = createBoundsFromCenterAndZoom(currentLocation, DEFAULT_ZOOM_LEVEL);
       if (initialBounds) {
         setMapBounds(initialBounds);
-        fetchPins(currentLocation, initialBounds, DEFAULT_ZOOM_LEVEL_LEVEL);
+        fetchPins(currentLocation, initialBounds, DEFAULT_ZOOM_LEVEL);
         lastBaseLocationRef.current = currentLocation;
         setMapCenter(currentLocation);
         setIsInitialized(true);
@@ -124,7 +121,7 @@ export default function MapWithBaseLocation({
       lastBaseLocationRef.current = baseLocation;
 
       // 새로운 baseLocation에 맞는 bounds 생성
-      const newBounds = createBoundsFromCenterAndZoom(baseLocation, DEFAULT_ZOOM_LEVEL_LEVEL);
+      const newBounds = createBoundsFromCenterAndZoom(baseLocation, DEFAULT_ZOOM_LEVEL);
       if (newBounds) {
         setMapBounds(newBounds);
         fetchPins(baseLocation, newBounds, mapZoomLevel); // 새로운 bounds 기준으로 fetch
@@ -144,7 +141,7 @@ export default function MapWithBaseLocation({
   useEffect(() => {
     if (searchLocation && isInitialized) {
       setMapCenter(searchLocation);
-      const newBounds = createBoundsFromCenterAndZoom(searchLocation, DEFAULT_ZOOM_LEVEL_LEVEL);
+      const newBounds = createBoundsFromCenterAndZoom(searchLocation, DEFAULT_ZOOM_LEVEL);
       if (newBounds) {
         setMapBounds(newBounds);
         fetchPins(searchLocation, newBounds, mapZoomLevel);

--- a/apps/user/src/app/(main)/map/components/NaverMap.tsx
+++ b/apps/user/src/app/(main)/map/components/NaverMap.tsx
@@ -26,6 +26,7 @@ interface NaverMapProps {
   zoom: number;
   pins?: Pin[];
   onBoundsChange?: (bounds: naver.maps.LatLngBounds, center: Coordinates) => void;
+  onZoomChange?: (zoom: number) => void;
 }
 // 카테고리별 아이콘 반환 함수
 function getCategoryIcon(category?: string) {
@@ -51,7 +52,13 @@ function getCategoryIcon(category?: string) {
  * @param onBoundsChange 지도 바운드 변경 시 호출되는 함수
  * @returns 지도 컴포넌트
  */
-export default function NaverMap({ loc, zoom = 15, pins, onBoundsChange }: NaverMapProps) {
+export default function NaverMap({
+  loc,
+  zoom = 15,
+  pins,
+  onBoundsChange,
+  onZoomChange,
+}: NaverMapProps) {
   const mapRef = useRef<NaverMapInstance | null>(null);
   const markerRefs = useRef<NaverMarker[]>([]);
   const clustererRef = useRef<MarkerClustering | null>(null);
@@ -124,8 +131,16 @@ export default function NaverMap({ loc, zoom = 15, pins, onBoundsChange }: Naver
           ]);
         });
       }
+
+      if (onZoomChange) {
+        window.naver.maps.Event.addListener(map, "zoomend", () => {
+          const zoom = map.getZoom();
+          console.log("zoom", zoom);
+          onZoomChange(zoom);
+        });
+      }
     }
-  }, [loc, onBoundsChange]);
+  }, [loc, onBoundsChange, onZoomChange]);
 
   // 마커/클러스터러 관리
   useEffect(() => {
@@ -177,7 +192,8 @@ export default function NaverMap({ loc, zoom = 15, pins, onBoundsChange }: Naver
       anchor: new window.naver.maps.Point(22, 44),
     };
     clustererRef.current = new window.MarkerClustering({
-      minClusterSize: 2,
+      // TODO: 클러스터 사이즈 변경 필요
+      minClusterSize: 1000,
       maxZoom: 14,
       map: mapRef.current,
       markers: newMarkers,

--- a/apps/user/src/app/(main)/map/layout.tsx
+++ b/apps/user/src/app/(main)/map/layout.tsx
@@ -16,14 +16,14 @@ export default function MapLayout({ children }: { children: React.ReactNode }) {
         }}
       />
 
-      <main
+      <div
         style={{
           height: "calc(100vh - 60px - 72px)",
           overflow: "hidden",
         }}
       >
         {children}
-      </main>
+      </div>
     </>
   );
 }

--- a/apps/user/src/app/(main)/search/components/SearchContainer.tsx
+++ b/apps/user/src/app/(main)/search/components/SearchContainer.tsx
@@ -1,27 +1,24 @@
 "use client";
 
 import { useState, useEffect, Suspense } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@workspace/ui/components/button";
 import SearchInput from "@/components/common/SearchInput";
-import CategoryBar from "@/components/common/CategoryBar";
-import { Category } from "@/types/category";
-import { ArrowLeft, MapPin, Search, Building, Tag } from "lucide-react";
+import { ArrowLeft, MapPin, Building, Tag } from "lucide-react";
 import { toast } from "sonner";
 import { getNearbyStores, GetNearbyStoresParams } from "@/service/store";
 import { useLocationStore } from "@/store/useLocationStore";
 import { fetchMapSearch } from "@/service/mapSearch";
 import { DEFAULT_LOCATION } from "@/types/constants";
 import { MapSuggestion } from "@/types/search";
+import { DEFAULT_ZOOM_LEVEL } from "@/app/(main)/map/components/MapWithBaseLocation";
 
 const SearchContainer = () => {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState<Category>({
-    categoryId: 0,
-    categoryName: "전체",
-  });
+
   const [searchResults, setSearchResults] = useState<MapSuggestion[]>([]);
   const [isSearching, setIsSearching] = useState(false);
 
@@ -55,49 +52,9 @@ const SearchContainer = () => {
     }
   };
 
-  const handleMapSearch = async () => {
-    if (!currentLocation) {
-      toast.error("현재 위치를 불러올 수 없습니다.");
-      return;
-    }
-
-    setIsSearching(true);
-
-    try {
-      // 실제 지도 검색 API 호출
-      const results = await getNearbyStores({
-        swLat: currentLocation[1] - 0.01,
-        swLng: currentLocation[0] - 0.01,
-        neLat: currentLocation[1] + 0.01,
-        neLng: currentLocation[0] + 0.01,
-        ...(selectedCategory.categoryId !== 0 && {
-          categoryId: selectedCategory.categoryId as number,
-        }),
-      });
-
-      // StoreContent를 MapSuggestion 형태로 변환
-      const formattedResults: MapSuggestion[] = results.map((store) => ({
-        suggestion: store.storeName,
-        category: store.category || "기타",
-        id: store.storeId,
-        type: "STORE",
-        longitude: store.longitude,
-        latitude: store.latitude,
-        address: "주소 정보 없음", // StoreContent에는 address가 없으므로 기본값 사용
-      }));
-
-      setSearchResults(formattedResults);
-    } catch (error) {
-      console.error("지도 검색 중 오류:", error);
-      toast.error("주변 매장을 불러오지 못했습니다.");
-    } finally {
-      setIsSearching(false);
-    }
-  };
-
   const handleResultClick = async (result: MapSuggestion) => {
     // STORE 타입일 때는 지도로 이동
-    if (result.type === "STORE" && result.latitude && result.longitude) {
+    if (result.type === "STORE") {
       const params = new URLSearchParams({
         lat: result.latitude.toString(),
         lng: result.longitude.toString(),
@@ -106,55 +63,70 @@ const SearchContainer = () => {
       });
       router.push(`/map?${params.toString()}`);
     } else if (result.type === "CATEGORY" || result.type === "BRAND") {
-      // CATEGORY나 BRAND 타입일 때는 해당 필터로 주변 검색 실행
-      if (!currentLocation) {
-        toast.error("현재 위치를 불러올 수 없습니다.");
-        return;
-      }
+      const params = new URLSearchParams({
+        lat: result.latitude.toString(),
+        lng: result.longitude.toString(),
+        // storeId: result.id.toString(),
+        searchQuery: searchQuery,
+      });
+      router.push(`/map?${params.toString()}`);
+      // // CATEGORY나 BRAND 타입일 때는 해당 필터로 주변 검색 실행
+      // if (!currentLocation) {
+      //   toast.error("현재 위치를 불러올 수 없습니다.");
+      //   return;
+      // }
 
-      setIsSearching(true);
+      // setIsSearching(true);
 
-      try {
-        const searchParams: GetNearbyStoresParams = {
-          swLat: currentLocation[1] - 0.01,
-          swLng: currentLocation[0] - 0.01,
-          neLat: currentLocation[1] + 0.01,
-          neLng: currentLocation[0] + 0.01,
-        };
+      // try {
+      //   const searchParams: GetNearbyStoresParams = {
+      //     swLat: currentLocation[1] - 0.01,
+      //     swLng: currentLocation[0] - 0.01,
+      //     neLat: currentLocation[1] + 0.01,
+      //     neLng: currentLocation[0] + 0.01,
+      //     zoomLevel: DEFAULT_ZOOM_LEVEL,
+      //   };
 
-        // 타입에 따라 필터 추가
-        if (result.type === "CATEGORY") {
-          searchParams.categoryId = result.id;
-        } else if (result.type === "BRAND") {
-          searchParams.brandId = result.id;
-        }
+      //   // 타입에 따라 필터 추가
+      //   if (result.type === "CATEGORY") {
+      //     searchParams.categoryId = result.id;
+      //   } else if (result.type === "BRAND") {
+      //     searchParams.brandId = result.id;
+      //   }
 
-        const results = await getNearbyStores(searchParams);
+      //   const results = await getNearbyStores(searchParams);
 
-        // StoreContent를 MapSuggestion 형태로 변환
-        const formattedResults: MapSuggestion[] = results.map((store) => ({
-          suggestion: store.storeName,
-          category: store.category || "기타",
-          id: store.storeId,
-          type: "STORE",
-          longitude: store.longitude,
-          latitude: store.latitude,
-          address: "주소 정보 없음",
-        }));
+      // StoreContent를 MapSuggestion 형태로 변환
+      // const formattedResults: MapSuggestion[] = results.map((store) => ({
+      //   suggestion: store.storeName,
+      //   category: store.category || "기타",
+      //   id: store.storeId,
+      //   type: "STORE",
+      //   longitude: store.longitude,
+      //   latitude: store.latitude,
+      //   address: "주소 정보 없음",
+      // }));
 
-        setSearchResults(formattedResults);
-        toast.success(`${result.suggestion} 관련 매장을 찾았습니다.`);
-      } catch (error) {
-        console.error("카테고리/브랜드 검색 중 오류:", error);
-        toast.error("해당 카테고리/브랜드의 매장을 찾을 수 없습니다.");
-      } finally {
-        setIsSearching(false);
-      }
+      // setSearchResults(formattedResults);
+      toast.success(`${result.suggestion} 관련 매장을 찾았습니다.`);
+      // } catch (error) {
+      //   console.error("카테고리/브랜드 검색 중 오류:", error);
+      //   toast.error("해당 카테고리/브랜드의 매장을 찾을 수 없습니다.");
+      // } finally {
+      //   setIsSearching(false);
+      // }
     }
   };
 
   const handleSearchInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
+    const params = new URLSearchParams(searchParams);
+    if (e.target.value) {
+      params.set("q", e.target.value);
+    } else {
+      params.delete("q");
+    }
+    router.push(`${pathname}?${params.toString()}`);
   };
 
   const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -162,16 +134,6 @@ const SearchContainer = () => {
       handleSearch(searchQuery);
     }
   };
-
-  // const handleCategoryChange = (category: Category) => {
-  //   setSelectedCategory(category);
-  //   // 카테고리 변경 시 현재 검색 타입에 따라 재검색
-  //   if (currentLocation) {
-  //     handleMapSearch();
-  //   } else if (searchQuery) {
-  //     handleSearch(searchQuery);
-  //   }
-  // };
 
   return (
     <div className="flex h-full flex-col bg-white">
@@ -192,64 +154,61 @@ const SearchContainer = () => {
 
       {/* 검색 결과 */}
       <div className="flex-1 overflow-y-auto">
-        {
-          isSearching ? (
-            <div className="flex h-full items-center justify-center">
-              <div className="text-gray-500">검색 중...</div>
-            </div>
-          ) : searchResults.length > 0 ? (
-            <div className="divide-y divide-gray-100">
-              {searchResults.map((result) => {
-                // 타입별 아이콘과 색상 결정
-                let icon = <MapPin className="h-5 w-5" />;
-                let bgColor = "bg-blue-100";
-                let iconColor = "text-blue-600";
+        {isSearching ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="text-gray-500">검색 중...</div>
+          </div>
+        ) : searchResults.length > 0 ? (
+          <div className="divide-y divide-gray-100">
+            {searchResults.map((result) => {
+              // 타입별 아이콘과 색상 결정
+              let icon = <MapPin className="h-5 w-5" />;
+              let bgColor = "bg-blue-100";
+              let iconColor = "text-blue-600";
 
-                if (result.type === "CATEGORY") {
-                  icon = <Tag className="h-5 w-5" />;
-                  bgColor = "bg-green-100";
-                  iconColor = "text-green-600";
-                } else if (result.type === "BRAND") {
-                  icon = <Building className="h-5 w-5" />;
-                  bgColor = "bg-purple-100";
-                  iconColor = "text-purple-600";
-                }
+              if (result.type === "CATEGORY") {
+                icon = <Tag className="h-5 w-5" />;
+                bgColor = "bg-green-100";
+                iconColor = "text-green-600";
+              } else if (result.type === "BRAND") {
+                icon = <Building className="h-5 w-5" />;
+                bgColor = "bg-purple-100";
+                iconColor = "text-purple-600";
+              }
 
-                return (
+              return (
+                <div
+                  key={result.id}
+                  className="flex cursor-pointer items-start gap-3 px-4 py-4 hover:bg-gray-50"
+                  onClick={() => handleResultClick(result)}
+                >
                   <div
-                    key={result.id}
-                    className="flex cursor-pointer items-start gap-3 px-4 py-4 hover:bg-gray-50"
-                    onClick={() => handleResultClick(result)}
+                    className={`flex h-10 w-10 items-center justify-center rounded-full ${bgColor}`}
                   >
-                    <div
-                      className={`flex h-10 w-10 items-center justify-center rounded-full ${bgColor}`}
-                    >
-                      <div className={iconColor}>{icon}</div>
-                    </div>
-                    <div className="flex-1">
-                      <h3 className="font-medium text-gray-900">{result.suggestion}</h3>
-                      {result.address && <p className="text-sm text-gray-500">{result.address}</p>}
-                      <div className="mt-1 flex items-center gap-2">
-                        <span className="text-xs text-blue-600">{result.category}</span>
-                        <span className="text-xs text-gray-400">{result.type}</span>
-                      </div>
+                    <div className={iconColor}>{icon}</div>
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="font-medium text-gray-900">{result.suggestion}</h3>
+                    {result.address && <p className="text-sm text-gray-500">{result.address}</p>}
+                    <div className="mt-1 flex items-center gap-2">
+                      <span className="text-xs text-blue-600">{result.category}</span>
+                      <span className="text-xs text-gray-400">{result.type}</span>
                     </div>
                   </div>
-                );
-              })}
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <div className="text-center">
+              <p className="text-gray-500">검색어를 입력하거나 주변 검색을 해보세요</p>
+              <p className="mt-1 text-sm text-gray-400">
+                제휴처 이름이나 키워드로 검색할 수 있습니다 (ex{">"} 강남 맛집)
+              </p>
             </div>
-          ) : (
-            <div className="flex h-full items-center justify-center">
-              <div className="text-center">
-                <p className="text-gray-500">검색어를 입력하거나 주변 검색을 해보세요</p>
-                <p className="mt-1 text-sm text-gray-400">
-                  제휴처 이름이나 주소로 검색할 수 있습니다
-                </p>
-              </div>
-            </div>
-          )
-          // )
-        }
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/user/src/service/store.ts
+++ b/apps/user/src/service/store.ts
@@ -13,6 +13,7 @@ export interface GetNearbyStoresParams {
   swLng: number;
   neLat: number;
   neLng: number;
+  zoomLevel: number;
   categoryId?: number;
   brandId?: number;
   season?: string;

--- a/apps/user/src/utils/fetchStorePins.ts
+++ b/apps/user/src/utils/fetchStorePins.ts
@@ -16,6 +16,7 @@ export async function fetchStorePins(
   center: Coordinates,
   bounds: naver.maps.LatLngBounds,
   category: Category,
+  zoomLevel: number,
   baseLocation?: Coordinates
 ): Promise<Pin[]> {
   try {
@@ -27,6 +28,7 @@ export async function fetchStorePins(
       swLng: sw.lng(),
       neLat: ne.lat(),
       neLng: ne.lng(),
+      zoomLevel,
       ...(typeof category.categoryId === "number" && category.categoryId !== 0
         ? { categoryId: category.categoryId }
         : {}),


### PR DESCRIPTION
## #️⃣연관된 이슈
#117 

## 📝작업 내용

- 서비스 함수 및 유틸 함수에 zoomLevel 추가
- zoom 변경 이벤트 리스너 추가

## 📷스크린샷 (선택)

> 변경사항을 첨부해주세요

## 💬리뷰 요구사항(선택)
zoom 콘솔로그는 함께 테스트시 확인을 위해 남겨두었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 지도에서 줌 레벨(확대/축소 단계)을 실시간으로 추적하여, 매장 핀 데이터 조회 시 현재 지도 줌 레벨을 반영합니다.
  * 지도 검색 입력창을 클릭하면 "/search" 페이지로 이동합니다.

* **개선 사항**
  * 지도 관련 동작이 더 정확하게 현재 화면 상태(줌 레벨 등)에 맞춰 반영됩니다.
  * 검색창에서 카테고리 기반 직접 매장 조회 기능이 제거되고, 검색 결과 클릭 시 쿼리 파라미터를 포함한 지도 페이지로 즉시 이동하도록 변경되었습니다.
  * 검색 입력 시 URL 쿼리 파라미터가 실시간으로 업데이트되어 검색 상태가 반영됩니다.

* **스타일**
  * 지도 레이아웃의 최상위 요소가 `<main>`에서 `<div>`로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->