### PR TITLE
[FEAT] UBLE-112 다크모드 강제 비활성화

### DIFF
--- a/apps/admin/src/components/providers.tsx
+++ b/apps/admin/src/components/providers.tsx
@@ -7,8 +7,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <NextThemesProvider
       attribute="class"
-      defaultTheme="system"
-      enableSystem
+      defaultTheme="light"
+      enableSystem={false}
       disableTransitionOnChange
       enableColorScheme
     >

--- a/apps/admin/src/components/providers.tsx
+++ b/apps/admin/src/components/providers.tsx
@@ -10,7 +10,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
       defaultTheme="light"
       enableSystem={false}
       disableTransitionOnChange
-      // enableColorScheme
     >
       {children}
     </NextThemesProvider>

--- a/apps/admin/src/components/providers.tsx
+++ b/apps/admin/src/components/providers.tsx
@@ -10,7 +10,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       defaultTheme="light"
       enableSystem={false}
       disableTransitionOnChange
-      enableColorScheme
+      // enableColorScheme
     >
       {children}
     </NextThemesProvider>

--- a/apps/user/src/app/layout.tsx
+++ b/apps/user/src/app/layout.tsx
@@ -9,6 +9,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <meta name="color-scheme" content="light" />
+      </head>
       <body>
         <Providers>
           <Toaster richColors position="top-center" />

--- a/apps/user/src/components/providers.tsx
+++ b/apps/user/src/components/providers.tsx
@@ -7,10 +7,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <NextThemesProvider
       attribute="class"
-      defaultTheme="system"
-      enableSystem
+      defaultTheme="light"
+      enableSystem={false}
       disableTransitionOnChange
-      enableColorScheme
+      // enableColorScheme
     >
       {children}
     </NextThemesProvider>

--- a/apps/user/src/components/providers.tsx
+++ b/apps/user/src/components/providers.tsx
@@ -10,7 +10,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
       defaultTheme="light"
       enableSystem={false}
       disableTransitionOnChange
-      // enableColorScheme
     >
       {children}
     </NextThemesProvider>

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -103,6 +103,13 @@
   --radius-xl: calc(var(--radius) + 4px);
 }
 
+@media (prefers-color-scheme: dark) {
+  html {
+    color-scheme: light;
+    background-color: white !important;
+    color: black !important;
+  }
+}
 @layer base {
   *,
   ::before,
@@ -118,7 +125,6 @@
 
   html {
     @apply scroll-auto antialiased;
-    color-scheme: light;
   }
 
   body {

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -118,6 +118,7 @@
 
   html {
     @apply scroll-auto antialiased;
+    color-scheme: light;
   }
 
   body {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #120 

## 📝작업 내용

Os 설정, 브라우저 설정을 무시하고 라이트모드 강제 설정

## 📷스크린샷 (선택)

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/48344fb8-e446-45a4-ac00-1eb92fc0570e" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 사용자 인터페이스의 기본 테마가 항상 라이트 모드로 고정되었습니다.
  * 시스템 테마 감지 및 색상 스킴 관리가 비활성화되었습니다.
  * 문서에 라이트 컬러 스킴을 명시적으로 지정하는 메타 태그가 추가되었습니다.
  * 다크 모드 환경에서도 라이트 테마가 강제로 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->