### PR TITLE
[FIX] UBLE-125 바텀탭, 스크롤바 none 롤백

### DIFF
--- a/apps/user/src/app/(main)/layout.tsx
+++ b/apps/user/src/app/(main)/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
       <ConfirmModal />
       <Header />
       <ReactQueryProvider>
-        <main>{children}</main>
+        <main style={{ paddingBottom: "72px" }}>{children}</main>
       </ReactQueryProvider>
       <Footer />
     </Fragment>

--- a/apps/user/src/components/common/CategoryBar.tsx
+++ b/apps/user/src/components/common/CategoryBar.tsx
@@ -19,7 +19,7 @@ const CategoryBar = ({ selectedCategory, onSelectCategory }: CategoryBarProps) =
   }
 
   return (
-    <nav className=" flex gap-2 overflow-x-auto whitespace-nowrap py-3">
+    <nav className="scrollbar-hide flex gap-2 overflow-x-auto whitespace-nowrap py-3">
       {categories.map((cat) => (
         <Button
           key={cat.categoryId}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #137 

## 📝작업 내용

바텀 탭 하단 공간 확보

스크롤바가 출력되지 않도록 롤백

## 📷스크린샷 (선택)

<img width="529" height="135" alt="image" src="https://github.com/user-attachments/assets/b1ab3ea6-337c-4fb5-b6cd-36329a296161" />

<img width="843" height="325" alt="image" src="https://github.com/user-attachments/assets/2bfd9983-1834-4821-9cf2-7fe07df64858" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 메인 콘텐츠 영역에 하단 패딩(72px)이 추가되어 레이아웃이 개선되었습니다.
  * 카테고리 바의 스크롤바가 숨겨져 더욱 깔끔한 디자인을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->