### PR TITLE
[FIX] UBLE-129 사용자가 카테고리를 해제했음에도 선택되어있는 문제 해결

### DIFF
--- a/apps/user/src/app/(no-layout)/signup/components/SelectCategory.tsx
+++ b/apps/user/src/app/(no-layout)/signup/components/SelectCategory.tsx
@@ -38,10 +38,11 @@ const SelectCategory = ({ info, setInfo }: StepProps) => {
 
             return (
               <Button
-                key={key}
+                key={`${key}-${isSelected}`}
                 onClick={() => toggleInterest(key)}
                 disabled={isDisabled}
                 variant={isSelected ? "onb_selected" : "onb_unselected"}
+                className={isSelected ? "" : "hover:bg-gray-100 hover:text-gray-600"}
               >
                 <span className="text-sm font-semibold">
                   {CATEGORIES[key as keyof typeof CATEGORIES]}

--- a/apps/user/src/components/modal/ProfileEditModalContents/CategorySelector.tsx
+++ b/apps/user/src/components/modal/ProfileEditModalContents/CategorySelector.tsx
@@ -27,10 +27,11 @@ const CategorySelector = ({ categoryIds, onChange }: CategorySelectorProps) => {
 
           return (
             <Button
-              key={key}
+              key={`${key}-${isSelected}`}
               onClick={() => toggleCategory(key)}
               disabled={isDisabled}
               variant={isSelected ? "onb_selected" : "onb_unselected"}
+              className={isSelected ? "" : "hover:bg-gray-100 hover:text-gray-600"}
             >
               <span className="text-sm font-semibold">
                 {CATEGORIES[key as keyof typeof CATEGORIES]}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #144 

## 📝작업 내용

사용자가 관심 카테고리를 해제했음에도 여전히 선택되어 있는 현상을 수정했습니다.

추가적으로 사용자에게 혼동을 줄 여지가 있어 선택되어 있지 않은 버튼의 hover 이벤트 동작을 없앴습니다.

## 📷스크린샷 (선택)

<img width="1440" height="1240" alt="image" src="https://github.com/user-attachments/assets/c141bf2a-9b33-4041-9294-cf3cbff581fd" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?