### PR TITLE
[FIX] UBLE-132 홈 검색 결과 하단 바텀내비 가려짐

### DIFF
--- a/apps/user/src/app/(main)/home/page.tsx
+++ b/apps/user/src/app/(main)/home/page.tsx
@@ -9,8 +9,8 @@ const HomePage = () => {
       <section>
         <div className="sticky top-12 z-10 bg-white">
           <SearchSection />
-          <SearchResults />
         </div>
+        <SearchResults />
         <HomeContent />
       </section>
     </Suspense>


### PR DESCRIPTION
## #️⃣연관된 이슈

#148 

## 📝작업 내용

 홈 검색 결과 하단 바텀내비 가려짐 해결

## 📷스크린샷 (선택)

![화면 기록 2025-07-30 오후 3 46 09](https://github.com/user-attachments/assets/08937eb5-4566-4564-8249-d7f84c85eda1)


## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 검색 결과 영역의 레이아웃이 변경되어, 검색 결과가 고정(sticky) 영역 밖에 표시됩니다.  
  * 기존 고정 영역에는 검색 입력 섹션만 남게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->