### PR TITLE
[FEAT] UBLE-136 관리자 통계 페이지 마크업

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "@workspace/ui": "workspace:*",
+    "chart.js": "^4.5.0",
     "lucide-react": "^0.475.0",
+    "react-chartjs-2": "^5.3.0",
     "sonner": "^2.0.6"
   },
   "devDependencies": {

--- a/apps/admin/src/app/(content)/statistics/components/ChartSelector.tsx
+++ b/apps/admin/src/app/(content)/statistics/components/ChartSelector.tsx
@@ -1,0 +1,26 @@
+import { statTypes } from "@/types/constants";
+import { Badge } from "@workspace/ui/components/badge";
+import React from "react";
+
+interface ChartSelectorProps {
+  activeStatType: string;
+  setActiveStatType: React.Dispatch<React.SetStateAction<string>>;
+}
+const ChartSelector = ({ activeStatType, setActiveStatType }: ChartSelectorProps) => {
+  return (
+    <div className="flex flex-wrap gap-2 overflow-x-auto pb-2">
+      {statTypes.map((type) => (
+        <Badge
+          key={type.id}
+          variant={activeStatType === type.id ? "default" : "outline"}
+          className="cursor-pointer whitespace-nowrap px-3 py-1"
+          onClick={() => setActiveStatType(type.id)}
+        >
+          {type.label}
+        </Badge>
+      ))}
+    </div>
+  );
+};
+
+export default ChartSelector;

--- a/apps/admin/src/app/(content)/statistics/components/RenderChart.tsx
+++ b/apps/admin/src/app/(content)/statistics/components/RenderChart.tsx
@@ -1,0 +1,137 @@
+import { barOptions, lineOptions } from "@/types/constants";
+import { Bar, Line } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  LineElement,
+  PointElement,
+  Title,
+  Tooltip,
+  Legend,
+  type ChartOptions,
+} from "chart.js";
+
+// Chart.js 등록
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  LineElement,
+  PointElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface RenderChartProps {
+  activeStatType: string;
+}
+
+const RenderChart = ({ activeStatType }: RenderChartProps) => {
+  const chartHeight = typeof window !== "undefined" && window.innerWidth < 768 ? 300 : 400;
+  const partnerViewData = {
+    labels: ["스타벅스", "맥도날드", "베스킨라빈스", "도미노피자", "쉐이크쉑"],
+    datasets: [
+      {
+        label: "조회수",
+        data: [4000, 3000, 2000, 2780, 1890],
+        backgroundColor: "rgba(59, 130, 246, 0.8)",
+        borderColor: "rgba(59, 130, 246, 1)",
+        borderWidth: 1,
+        borderRadius: 4,
+      },
+    ],
+  };
+
+  const districtData = {
+    labels: ["강남구", "서초구", "송파구", "마포구", "종로구"],
+    datasets: [
+      {
+        label: "이용수",
+        data: [3500, 2800, 2400, 2100, 1900],
+        backgroundColor: "rgba(34, 197, 94, 0.8)",
+        borderColor: "rgba(34, 197, 94, 1)",
+        borderWidth: 1,
+        borderRadius: 4,
+      },
+    ],
+  };
+
+  const trendData = {
+    labels: ["1월", "2월", "3월", "4월", "5월", "6월"],
+    datasets: [
+      {
+        label: "카페",
+        data: [4000, 3000, 2000, 2780, 1890, 2390],
+        borderColor: "rgba(59, 130, 246, 1)",
+        backgroundColor: "rgba(59, 130, 246, 0.1)",
+        tension: 0.4,
+        fill: true,
+      },
+      {
+        label: "패스트푸드",
+        data: [2400, 1398, 9800, 3908, 4800, 3800],
+        borderColor: "rgba(34, 197, 94, 1)",
+        backgroundColor: "rgba(34, 197, 94, 0.1)",
+        tension: 0.4,
+        fill: true,
+      },
+      {
+        label: "디저트",
+        data: [2400, 2210, 2290, 2000, 2181, 2500],
+        borderColor: "rgba(251, 191, 36, 1)",
+        backgroundColor: "rgba(251, 191, 36, 0.1)",
+        tension: 0.4,
+        fill: true,
+      },
+    ],
+  };
+
+  const keywordData = {
+    labels: ["스타벅스", "맥도날드", "카페", "치킨", "피자"],
+    datasets: [
+      {
+        label: "검색 횟수",
+        data: [1200, 980, 850, 720, 650],
+        backgroundColor: "rgba(249, 115, 22, 0.8)",
+        borderColor: "rgba(249, 115, 22, 1)",
+        borderWidth: 1,
+        borderRadius: 4,
+      },
+    ],
+  };
+  switch (activeStatType) {
+    case "click":
+    case "usage":
+      return (
+        <div style={{ height: chartHeight }}>
+          <Bar data={partnerViewData} options={barOptions} />
+        </div>
+      );
+    case "local":
+      return (
+        <div style={{ height: chartHeight }}>
+          <Bar data={districtData} options={barOptions} />
+        </div>
+      );
+    case "interest-change":
+      return (
+        <div style={{ height: chartHeight }}>
+          <Line data={trendData} options={lineOptions} />
+        </div>
+      );
+    case "keywords/daily-top":
+    case "keywords/empty-top":
+      return (
+        <div style={{ height: chartHeight }}>
+          <Bar data={keywordData} options={barOptions} />
+        </div>
+      );
+    default:
+      return null;
+  }
+};
+
+export default RenderChart;

--- a/apps/admin/src/app/(content)/statistics/components/RenderChart.tsx
+++ b/apps/admin/src/app/(content)/statistics/components/RenderChart.tsx
@@ -12,6 +12,7 @@ import {
   Legend,
   type ChartOptions,
 } from "chart.js";
+import { useEffect, useState } from "react";
 
 // Chart.js 등록
 ChartJS.register(
@@ -30,7 +31,18 @@ interface RenderChartProps {
 }
 
 const RenderChart = ({ activeStatType }: RenderChartProps) => {
-  const chartHeight = typeof window !== "undefined" && window.innerWidth < 768 ? 300 : 400;
+  const [chartHeight, setChartHeight] = useState(400);
+
+  useEffect(() => {
+    const updateHeight = () => {
+      setChartHeight(window.innerWidth < 768 ? 300 : 400);
+    };
+
+    updateHeight();
+    window.addEventListener("resize", updateHeight);
+    return () => window.removeEventListener("resize", updateHeight);
+  }, []);
+
   const partnerViewData = {
     labels: ["스타벅스", "맥도날드", "베스킨라빈스", "도미노피자", "쉐이크쉑"],
     datasets: [

--- a/apps/admin/src/app/(content)/statistics/components/StatisticsChartContainer.tsx
+++ b/apps/admin/src/app/(content)/statistics/components/StatisticsChartContainer.tsx
@@ -7,10 +7,10 @@ import RenderChart from "./RenderChart";
 import { statTypes } from "@/types/constants";
 import { StatisticsFilter } from "@/types/statistics";
 
-interface StatisticsCharContainerProps {
+interface StatisticsChartContainerProps {
   params: StatisticsFilter;
 }
-const StatisticsChartContainer = ({ params }: StatisticsCharContainerProps) => {
+const StatisticsChartContainer = ({ params }: StatisticsChartContainerProps) => {
   const [activeStatType, setActiveStatType] = useState("click");
   return (
     <Fragment>

--- a/apps/admin/src/app/(content)/statistics/components/StatisticsChartContainer.tsx
+++ b/apps/admin/src/app/(content)/statistics/components/StatisticsChartContainer.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Fragment, useState } from "react";
+import ChartSelector from "./ChartSelector";
+import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card";
+import RenderChart from "./RenderChart";
+import { statTypes } from "@/types/constants";
+import { StatisticsFilter } from "@/types/statistics";
+
+interface StatisticsCharContainerProps {
+  params: StatisticsFilter;
+}
+const StatisticsChartContainer = ({ params }: StatisticsCharContainerProps) => {
+  const [activeStatType, setActiveStatType] = useState("click");
+  return (
+    <Fragment>
+      <ChartSelector activeStatType={activeStatType} setActiveStatType={setActiveStatType} />
+      <Card>
+        <CardHeader>
+          <CardTitle className="mt-5 text-xl font-bold">
+            {statTypes.find((type) => type.id === activeStatType)?.label}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-6 pt-0">
+          <RenderChart activeStatType={activeStatType} />
+        </CardContent>
+      </Card>
+    </Fragment>
+  );
+};
+
+export default StatisticsChartContainer;

--- a/apps/admin/src/app/(content)/statistics/components/StatisticsContainer.tsx
+++ b/apps/admin/src/app/(content)/statistics/components/StatisticsContainer.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useState } from "react";
+import { StatisticsFilter as StatisticsType } from "@/types/statistics";
+import StatisticsFilter from "./StatisticsFilter";
+import StatisticsChartContainer from "./StatisticsChartContainer";
+
+const StatisticsContainer = () => {
+  const [filters, setFilters] = useState<StatisticsType>({
+    rankTarget: "BRAND",
+    gender: "MALE",
+    ageRange: 10,
+    rank: "NONE",
+    benefitType: "NORMAL",
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 md:text-3xl">통계 조회</h2>
+        <p className="mt-2 text-sm text-gray-600 md:text-base">다양한 조건으로 통계를 확인하세요</p>
+      </div>
+      {/* 필터 섹션 */}
+      <StatisticsFilter filters={filters} setFilters={setFilters} />
+      {/* 통계 타입 선택, 차트 출력 */}
+      <StatisticsChartContainer params={filters} />
+    </div>
+  );
+};
+
+export default StatisticsContainer;

--- a/apps/admin/src/app/(content)/statistics/components/StatisticsFilter.tsx
+++ b/apps/admin/src/app/(content)/statistics/components/StatisticsFilter.tsx
@@ -1,0 +1,153 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card";
+import { filterOptions } from "@/types/constants";
+import { AgeRangeType, StatisticsFilter as StatisticsType } from "@/types/statistics";
+import { Button } from "@workspace/ui/components/button";
+
+interface StatisticsFilterProps {
+  filters: StatisticsType;
+  setFilters: React.Dispatch<React.SetStateAction<StatisticsType>>;
+}
+const StatisticsFilter = ({ filters, setFilters }: StatisticsFilterProps) => {
+  return (
+    <Card className="border-none pb-5 pt-5">
+      <CardHeader>
+        <CardTitle className="text-xl font-bold">필터 설정</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700">통계 대상</label>
+            <Select
+              value={filters.rankTarget}
+              onValueChange={(value: "BRAND" | "CATEGORY") =>
+                setFilters({ ...filters, rankTarget: value })
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {filterOptions.rankTarget.map((t) => (
+                  <SelectItem key={t} value={t === "BRAND" ? "BRAND" : t}>
+                    {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700">카테고리</label>
+            <Select
+              value={filters.gender}
+              onValueChange={(value: "MALE" | "FEMALE") =>
+                setFilters({ ...filters, gender: value })
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {filterOptions.gender.map((g) => (
+                  <SelectItem key={g} value={g === "MALE" ? "MALE" : g}>
+                    {g}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700">나이대</label>
+            <Select
+              value={String(filters.ageRange)}
+              onValueChange={(value) =>
+                setFilters({ ...filters, ageRange: Number(value) as AgeRangeType })
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {filterOptions.ageRange.map((age) => (
+                  <SelectItem key={age} value={String(age)}>
+                    {age}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700">사용자 등급</label>
+            <Select
+              value={filters.rank}
+              onValueChange={(value: "NONE" | "NORMAL" | "PREMIUM" | "VIP" | "VVIP") =>
+                setFilters({ ...filters, rank: value })
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {filterOptions.rank.map((grade) => (
+                  <SelectItem key={grade} value={grade === "NONE" ? "NONE" : grade}>
+                    {grade}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700">혜택 타입</label>
+            <Select
+              value={filters.benefitType}
+              onValueChange={(value: "VIP" | "LOCAL" | "NORMAL") =>
+                setFilters({ ...filters, benefitType: value })
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {filterOptions.benefitType.map((type) => (
+                  <SelectItem key={type} value={type === "NORMAL" ? "NORMAL" : type}>
+                    {type}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="mt-4 flex space-x-2">
+          <Button>필터 적용</Button>
+          <Button
+            variant="outline"
+            onClick={() =>
+              setFilters({
+                rankTarget: "BRAND",
+                gender: "MALE",
+                ageRange: 10,
+                rank: "NONE",
+                benefitType: "NORMAL",
+              })
+            }
+          >
+            초기화
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default StatisticsFilter;

--- a/apps/admin/src/app/(content)/statistics/components/StatisticsFilter.tsx
+++ b/apps/admin/src/app/(content)/statistics/components/StatisticsFilter.tsx
@@ -44,7 +44,7 @@ const StatisticsFilter = ({ filters, setFilters }: StatisticsFilterProps) => {
           </div>
 
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">카테고리</label>
+            <label className="mb-2 block text-sm font-medium text-gray-700">성별</label>
             <Select
               value={filters.gender}
               onValueChange={(value: "MALE" | "FEMALE") =>

--- a/apps/admin/src/app/(content)/statistics/page.tsx
+++ b/apps/admin/src/app/(content)/statistics/page.tsx
@@ -1,5 +1,11 @@
+import StatisticsContainer from "./components/StatisticsContainer";
+
 const page = () => {
-  return <div></div>;
+  return (
+    <div>
+      <StatisticsContainer />
+    </div>
+  );
 };
 
 export default page;

--- a/apps/admin/src/types/constants.ts
+++ b/apps/admin/src/types/constants.ts
@@ -1,0 +1,94 @@
+export const filterOptions = {
+  rankTarget: ["BRAND", "CATEGORY"] as const,
+  gender: ["MALE", "FEMALE"] as const,
+  ageRange: [10, 20, 30, 40, 50, 60, 70, 80, 90] as const,
+  rank: ["NONE", "NORMAL", "PREMIUM", "VIP", "VVIP"] as const,
+  benefitType: ["VIP", "LOCAL", "NORMAL"] as const,
+};
+
+export type StatisticsFilterOption = typeof filterOptions;
+
+import { ChartOptions } from "chart.js";
+
+export const barOptions: ChartOptions<"bar"> = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      position: "top",
+      labels: {
+        font: { size: 12 },
+        padding: 20,
+      },
+    },
+    tooltip: {
+      backgroundColor: "rgba(0, 0, 0, 0.8)",
+      titleColor: "white",
+      bodyColor: "white",
+      borderColor: "rgba(255, 255, 255, 0.1)",
+      borderWidth: 1,
+      cornerRadius: 8,
+      displayColors: false,
+    },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      ticks: { font: { size: 11 } },
+    },
+    y: {
+      beginAtZero: true,
+      grid: { color: "rgba(0, 0, 0, 0.1)" },
+      ticks: { font: { size: 11 } },
+    },
+  },
+};
+
+export const lineOptions: ChartOptions<"line"> = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      position: "top",
+      labels: {
+        font: { size: 12 },
+        padding: 20,
+        usePointStyle: true,
+      },
+    },
+    tooltip: {
+      backgroundColor: "rgba(0, 0, 0, 0.8)",
+      titleColor: "white",
+      bodyColor: "white",
+      borderColor: "rgba(255, 255, 255, 0.1)",
+      borderWidth: 1,
+      cornerRadius: 8,
+      mode: "index",
+      intersect: false,
+    },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      ticks: { font: { size: 11 } },
+    },
+    y: {
+      beginAtZero: true,
+      grid: { color: "rgba(0, 0, 0, 0.1)" },
+      ticks: { font: { size: 11 } },
+    },
+  },
+  interaction: {
+    mode: "index",
+    intersect: false,
+  },
+};
+
+export const statTypes = [
+  { id: "click", label: "제휴처/카테고리 클릭 순위" },
+  { id: "interest-change", label: "상위 10개 제휴처 대상 관심사 변화 추이" },
+  { id: "keywords/daily-top", label: "일별 인기 검색어 순위" },
+  { id: "keywords/empty-top", label: "결과 미포함 검색어 순위" },
+  { id: "local", label: "서울 지역구 이용 순위" },
+  { id: "usage", label: "제휴처/카테고리 이용 순위" },
+];

--- a/apps/admin/src/types/statistics.ts
+++ b/apps/admin/src/types/statistics.ts
@@ -7,11 +7,3 @@ export interface StatisticsFilter {
 }
 
 export type AgeRangeType = 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90;
-
-// export interface StatisticsFilterOption {
-//   rankTarget: Array<"BRAND" | "CATEGORY">;
-//   gender: Array<"MALE" | "FEMALE">;
-//   ageRange: Array<10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100>;
-//   rank: Array<"NORMAL" | "PREMIUM" | "VIP" | "VVIP" | "NONE">;
-//   benefitType: Array<"VIP" | "LOCAL" | "NORMAL">;
-// }

--- a/apps/admin/src/types/statistics.ts
+++ b/apps/admin/src/types/statistics.ts
@@ -1,0 +1,17 @@
+export interface StatisticsFilter {
+  rankTarget: "BRAND" | "CATEGORY";
+  gender: "MALE" | "FEMALE";
+  ageRange: AgeRangeType;
+  rank: "NORMAL" | "PREMIUM" | "VIP" | "VVIP" | "NONE";
+  benefitType: "VIP" | "LOCAL" | "NORMAL";
+}
+
+export type AgeRangeType = 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90;
+
+// export interface StatisticsFilterOption {
+//   rankTarget: Array<"BRAND" | "CATEGORY">;
+//   gender: Array<"MALE" | "FEMALE">;
+//   ageRange: Array<10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100>;
+//   rank: Array<"NORMAL" | "PREMIUM" | "VIP" | "VVIP" | "NONE">;
+//   benefitType: Array<"VIP" | "LOCAL" | "NORMAL">;
+// }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-radio-group": "^1.3.7",
+    "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.1.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,15 @@ importers:
       '@workspace/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      chart.js:
+        specifier: ^4.5.0
+        version: 4.5.0
       lucide-react:
         specifier: ^0.475.0
         version: 0.475.0(react@19.1.0)
+      react-chartjs-2:
+        specifier: ^5.3.0
+        version: 5.3.0(chart.js@4.5.0)(react@19.1.0)
       sonner:
         specifier: ^2.0.6
         version: 2.0.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1287,6 +1293,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
   '@mdx-js/react@3.1.0':
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
@@ -2766,6 +2775,10 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  chart.js@4.5.0:
+    resolution: {integrity: sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==}
+    engines: {pnpm: '>=8'}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -4585,6 +4598,12 @@ packages:
     resolution: {integrity: sha512-pc4ftnO5syHa/UjCruEeRsomlhoxKSugIgTA8T4dH0fvc89UMHL+/1Sp25IAphqG44pJkE5hMXhv89iS09jQyw==}
     peerDependencies:
       react: 16 - 19
+
+  react-chartjs-2@5.3.0:
+    resolution: {integrity: sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==}
+    peerDependencies:
+      chart.js: ^4.1.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-day-picker@9.8.0:
     resolution: {integrity: sha512-E0yhhg7R+pdgbl/2toTb0xBhsEAtmAx1l7qjIWYfcxOy8w4rTSVfbtBoSzVVhPwKP/5E9iL38LivzoE3AQDhCQ==}
@@ -6678,6 +6697,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  '@kurkle/color@0.3.4': {}
+
   '@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       '@types/mdx': 2.0.13
@@ -8227,6 +8248,10 @@ snapshots:
       upper-case-first: 1.1.2
 
   chardet@0.7.0: {}
+
+  chart.js@4.5.0:
+    dependencies:
+      '@kurkle/color': 0.3.4
 
   check-error@2.1.1: {}
 
@@ -10141,6 +10166,11 @@ snapshots:
     dependencies:
       jsbarcode: 3.12.1
       prop-types: 15.8.1
+      react: 19.1.0
+
+  react-chartjs-2@5.3.0(chart.js@4.5.0)(react@19.1.0):
+    dependencies:
+      chart.js: 4.5.0
       react: 19.1.0
 
   react-day-picker@9.8.0(react@19.1.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       '@radix-ui/react-radio-group':
         specifier: ^1.3.7
         version: 1.3.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-select':
+        specifier: ^2.2.5
+        version: 2.2.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
@@ -1386,6 +1389,9 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
@@ -1655,6 +1661,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-select@2.2.5':
+    resolution: {integrity: sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
@@ -1743,6 +1762,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/rect@1.1.1':
@@ -6763,6 +6795,8 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.2': {}
 
   '@radix-ui/react-alert-dialog@1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
@@ -7030,6 +7064,35 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
+  '@radix-ui/react-select@2.2.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.1(@types/react@19.1.8)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
@@ -7097,6 +7160,15 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
   '@radix-ui/rect@1.1.1': {}
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #155 

## 📝작업 내용

관리자 페이지 마크업

공통으로 사용되는 상수 선언

컴포넌트 책임 분리

## 📷스크린샷 (선택)

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/e8dfbd0f-1e5a-48d9-a35e-b23c224c5347" />

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/eb4a5344-f045-45d9-b3a2-03390bd4a027" />


## 💬리뷰 요구사항(선택)

option들은 서버의 요청 양식에 맞게 구현되어 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 통계 페이지에 다양한 필터(랭킹 대상, 성별, 연령대, 유저 등급, 혜택 유형)와 차트(Bar, Line) 시각화 기능이 추가되었습니다.
  * 통계 유형 선택 UI(ChartSelector)와 필터 설정/초기화 기능이 제공됩니다.
  * 반응형 차트(RenderChart)와 필터링된 데이터를 기반으로 한 통계 시각화가 가능합니다.
  * 통계 관련 컴포넌트들이 통합된 StatisticsContainer가 페이지에 추가되었습니다.

* **UI 개선**
  * 커스텀 드롭다운 Select 컴포넌트가 추가되어 필터 선택이 더욱 직관적으로 개선되었습니다.

* **의존성 추가**
  * 차트 시각화를 위한 Chart.js, react-chartjs-2, Radix UI Select가 새롭게 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->