### PR TITLE
[STYLE] UBLE-142 bottom tab 높이를 55px로 맞춤

### DIFF
--- a/apps/user/src/app/(main)/layout.tsx
+++ b/apps/user/src/app/(main)/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
       <ConfirmModal />
       <Header />
       <ReactQueryProvider>
-        <main style={{ paddingBottom: "72px" }}>{children}</main>
+        <main style={{ paddingBottom: "55px" }}>{children}</main>
       </ReactQueryProvider>
       <Footer />
     </Fragment>

--- a/apps/user/src/app/(main)/map/layout.tsx
+++ b/apps/user/src/app/(main)/map/layout.tsx
@@ -18,7 +18,7 @@ export default function MapLayout({ children }: { children: React.ReactNode }) {
 
       <div
         style={{
-          height: "calc(100dvh - 55px - 72px)",
+          height: "calc(100dvh - 55px - 55px)",
           overflow: "hidden",
         }}
       >

--- a/apps/user/src/components/common/Footer.tsx
+++ b/apps/user/src/components/common/Footer.tsx
@@ -15,8 +15,8 @@ export default function Footer() {
   ];
 
   return (
-    <div className="border-border fixed bottom-0 left-0 right-0 border-t bg-white">
-      <div className="flex w-full justify-around py-2">
+    <nav className="border-border fixed bottom-0 left-0 right-0 h-[56px] border-t bg-white">
+      <div className="flex h-full w-full justify-around">
         {navItems.map(({ path, icon: Icon, label }) => (
           <button
             key={path}
@@ -25,11 +25,11 @@ export default function Footer() {
               pathname === path ? "text-gray-900" : "text-gray-400"
             }`}
           >
-            <Icon className="mb-1 h-5 w-5" />
+            <Icon className="mb-0.5 h-5 w-5" />
             <span className="text-xs">{label}</span>
           </button>
         ))}
       </div>
-    </div>
+    </nav>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #163 

## 📝작업 내용

bottom tab 높이를 56px로 조정

## 📷스크린샷 (선택)

<img width="695" height="953" alt="image" src="https://github.com/user-attachments/assets/c0586dac-524f-4e5b-98a9-dbfd4e538e77" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 메인 레이아웃과 지도 레이아웃의 하단 패딩 및 높이 계산이 조정되어 화면 배치가 개선되었습니다.
  * 푸터 내비게이션이 시맨틱한 `<nav>` 요소로 변경되고, 높이 및 아이콘 간격이 조정되어 더 깔끔한 레이아웃을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->