### PR TITLE
[HOTFIX] UBLE-143 바코드가 없어도 혜택 사용이 가능한 현상 수정

### DIFF
--- a/apps/user/src/components/modal/BenefitConfirmModal.tsx
+++ b/apps/user/src/components/modal/BenefitConfirmModal.tsx
@@ -20,10 +20,8 @@ const BenefitConfirmModal = () => {
   };
 
   const invalidate = () => {
-    queryClient.invalidateQueries({
-      predicate: (query) =>
-        ["userStatistics", "usageHistory"].includes(query.queryKey[0] as string),
-    });
+    queryClient.invalidateQueries({ queryKey: ["userStatistics"] });
+    queryClient.invalidateQueries({ queryKey: ["usageHistory"] });
   };
   const handleYes = async (benefitType: "NORMAL" | "VIP" = "NORMAL") => {
     if (storeId !== null) {

--- a/apps/user/src/components/ui/BarcodeContainer.tsx
+++ b/apps/user/src/components/ui/BarcodeContainer.tsx
@@ -38,7 +38,6 @@ const BarcodeContainer = ({
         className={`relative cursor-pointer rounded-lg bg-gray-50 p-6 transition-all duration-300 ${
           !isBarcodeRevealed && barcode ? "hover:bg-gray-100" : ""
         }`}
-        onClick={handleBarcodeClick}
       >
         <div className="text-center">
           {barcode ? (
@@ -59,7 +58,11 @@ const BarcodeContainer = ({
             </div>
           )}
         </div>
-        {!isBarcodeRevealed && barcode && <BarcodeBlur />}
+        {!isBarcodeRevealed && barcode && (
+          <div onClick={handleBarcodeClick}>
+            <BarcodeBlur />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #165 

## 📝작업 내용

바코드가 없어도 혜택 사용이 가능한 현상을 수정했습니다.

혜택 사용 확인 모달은 오로지 BarcodeBlur 터치로만 열립니다.

## 📷스크린샷 (선택)

> 변경사항을 첨부해주세요

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 통계 및 사용 내역 정보 갱신 시, 쿼리 무효화 범위가 명확하게 분리되어 더 정확하게 데이터가 갱신됩니다.
  * 바코드 표시 영역에서 클릭 가능한 범위가 블러 처리된 바코드 부분으로 제한되어, 의도치 않은 영역 클릭 시 바코드가 노출되지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->