### PR TITLE
[FIX] UBLE-141 매장 상세 카드 즐겨찾기 동기화

### DIFF
--- a/apps/user/src/components/FavoriteBtn.tsx
+++ b/apps/user/src/components/FavoriteBtn.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { BrandContent, BrandListData, FetchBrandsParams } from "@/types/brand";
 import { fetchBrands } from "@/service/brand";
+import useStoreDetailDrawerStore from "@/store/useStoreDetailDrawerStore";
 
 interface FavoriteBtnProps {
   brandId: number;
@@ -17,6 +18,8 @@ interface FavoriteBtnProps {
 const FavoriteBtn = ({ brandId, bookmarked = false, variant }: FavoriteBtnProps) => {
   const queryClient = useQueryClient();
   const [isLiked, setIsLiked] = useState(bookmarked);
+  const { updateBookmarkStatus } = useStoreDetailDrawerStore();
+
   useEffect(() => {
     setIsLiked(bookmarked);
   }, [bookmarked]);
@@ -68,6 +71,8 @@ const FavoriteBtn = ({ brandId, bookmarked = false, variant }: FavoriteBtnProps)
     },
     onSuccess: async (newState) => {
       setIsLiked((prev) => !prev);
+      updateBookmarkStatus(!isLiked); // 현재 상태의 반대값으로 업데이트
+
       // 1) "brands" 로 시작하는 모든 infiniteQuery 키만 골라서
       const brandQueries = queryClient.getQueriesData<{
         pages: BrandListData[];
@@ -122,6 +127,7 @@ const FavoriteBtn = ({ brandId, bookmarked = false, variant }: FavoriteBtnProps)
     },
     onError: (error: Error) => {
       setIsLiked((prev) => !prev); // 실패했으면 상태 복구
+      updateBookmarkStatus(isLiked); // StoreDetailDrawer 상태도 복구
       toast.error("오류가 발생했습니다. 잠시 후 다시 이용해 주세요.");
     },
     onSettled: invalidate,

--- a/apps/user/src/store/useStoreDetailDrawerStore.ts
+++ b/apps/user/src/store/useStoreDetailDrawerStore.ts
@@ -20,6 +20,7 @@ interface StoreDetailDrawerState {
   close: () => void;
   setSnapIndex: (index: number) => void;
   loadDetail: (baseLocation: Coordinates) => Promise<void>;
+  updateBookmarkStatus: (isBookmarked: boolean) => void;
   reset: () => void;
 }
 
@@ -72,6 +73,18 @@ const useStoreDetailDrawerStore = create<StoreDetailDrawerState>((set, get) => (
       toast.error("가맹점 상세 정보를 불러오지 못했습니다.");
       set({ isDetailLoading: false });
     }
+  },
+
+  updateBookmarkStatus: (isBookmarked: boolean) => {
+    const { summary } = get();
+    if (!summary) return;
+
+    set({
+      summary: {
+        ...summary,
+        isBookmarked,
+      },
+    });
   },
 
   reset: () => {


### PR DESCRIPTION
## #️⃣연관된 이슈

#161

## 📝작업 내용

- useStoreDetailDrawerStore의 summary 상태 업데이트를 추가한다 .

## 📷스크린샷 (선택)
![화면 기록 2025-08-02 오전 2 31 51](https://github.com/user-attachments/assets/23f598bd-1171-40b8-9bed-69748d4147ae)


## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 즐겨찾기 버튼의 상태가 스토어 상세 정보 창과 동기화되어, 즐겨찾기 추가/해제 시 UI가 정확하게 반영됩니다.  
* **신규 기능**
  * 스토어 상세 정보 창에서 즐겨찾기 상태가 실시간으로 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->