### PR TITLE
[FEAT] UBLE-153 피드백 리스트 열람

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.83.0",
     "@workspace/ui": "workspace:*",
     "chart.js": "^4.5.0",
     "lucide-react": "^0.475.0",

--- a/apps/admin/src/app/(content)/feedback/components/FeedbackContainer.tsx
+++ b/apps/admin/src/app/(content)/feedback/components/FeedbackContainer.tsx
@@ -1,51 +1,36 @@
 "use client";
 import { Fragment, useState } from "react";
 import FeedbackStatistics from "./FeedbackStatistics";
-import { FeedbackData } from "@/types/feedback";
 import FeedbackList from "./FeedbackList";
 import Pagination from "./Pagination";
-
-const PAGE_SIZE = 10;
+import { useQuery } from "@tanstack/react-query";
+import { fetchFeedbackList } from "@/service/feedback";
+import FeedbackSkeleton from "./ui/FeedbackSkeleton";
+import FeedbackError from "./ui/FeedbackError";
 
 const FeedbackContainer = () => {
   const [currentPage, setCurrentPage] = useState(1);
 
   /** 향후 구현 fetching 함수 */
-  // const { data, isLoading, isError } = useQuery({
-  //   queryKey: ["feedbacks", currentPage],
-  //   queryFn: () => fetchFeedbacks(currentPage),
-  //   keepPreviousData: true,
-  // });
-  const feedbackData: FeedbackData = {
-    content: [
-      {
-        title: "UI 개선 요청",
-        content: "지도에서 핀을 더 크게 해주세요.",
-        score: 4,
-        createdAt: "2025-07-31T05:20:49.219Z",
-        nickname: "오잉",
-      },
-      {
-        title: "서비스가 정말 좋아요!",
-        content:
-          "지도에서 제휴처를 쉽게 찾을 수 있어서 너무 편리합니다. 할인 혜택도 잘 적용되고 있어요.",
-        score: 5,
-        createdAt: "2025-07-30T14:30:22.123Z",
-        nickname: "김민수",
-      },
-    ],
-    totalCount: 30,
-    totalPages: 3,
-  };
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ["feedbacks", currentPage],
+    queryFn: () => fetchFeedbackList(currentPage - 1),
+  });
+
+  if (isLoading) {
+    return <FeedbackSkeleton />;
+  }
+
+  if (isError || !data) {
+    return <FeedbackError refetch={refetch} />;
+  }
+  console.log(data.data.totalCount);
+  const { content, totalCount, totalPages } = data.data;
   return (
     <Fragment>
-      <FeedbackStatistics feedbackData={feedbackData} />
-      <FeedbackList feedbacks={feedbackData.content} />
-      <Pagination
-        currentPage={currentPage}
-        totalPages={feedbackData.totalPages}
-        onPageChange={setCurrentPage}
-      />
+      <FeedbackStatistics totalCount={totalCount} />
+      <FeedbackList feedbacks={content} />
+      <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
     </Fragment>
   );
 };

--- a/apps/admin/src/app/(content)/feedback/components/FeedbackStatistics.tsx
+++ b/apps/admin/src/app/(content)/feedback/components/FeedbackStatistics.tsx
@@ -3,9 +3,9 @@ import { Card, CardContent } from "@workspace/ui/components/card";
 import { MessageSquare } from "lucide-react";
 
 interface FeedbackStatisticsProps {
-  feedbackData: FeedbackData;
+  totalCount: number;
 }
-const FeedbackStatistics = ({ feedbackData }: FeedbackStatisticsProps) => {
+const FeedbackStatistics = ({ totalCount }: FeedbackStatisticsProps) => {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
       <Card className="border-none">
@@ -13,7 +13,7 @@ const FeedbackStatistics = ({ feedbackData }: FeedbackStatisticsProps) => {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-gray-600">전체 피드백</p>
-              <p className="text-3xl font-bold">{feedbackData.totalCount}</p>
+              <p className="text-3xl font-bold">{totalCount}</p>
             </div>
             <MessageSquare className="h-10 w-10 text-blue-500" />
           </div>

--- a/apps/admin/src/app/(content)/feedback/components/ui/FeedbackError.tsx
+++ b/apps/admin/src/app/(content)/feedback/components/ui/FeedbackError.tsx
@@ -1,0 +1,19 @@
+import { UseQueryResult } from "@tanstack/react-query";
+import { Button } from "@workspace/ui/components/button";
+import { AlertTriangle } from "lucide-react";
+
+interface FeedbackErrorProps {
+  refetch: () => ReturnType<UseQueryResult["refetch"]>;
+}
+const FeedbackError = ({ refetch }: FeedbackErrorProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 px-4 py-20 text-center">
+      <AlertTriangle className="text-destructive h-10 w-10" />
+      <p className="text-lg font-semibold text-gray-800">데이터를 불러오는 중 문제가 발생했어요.</p>
+      <p className="text-sm text-gray-500">네트워크 상태를 확인하거나, 다시 시도해 주세요.</p>
+      <Button onClick={() => refetch()}>다시 시도하기</Button>
+    </div>
+  );
+};
+
+export default FeedbackError;

--- a/apps/admin/src/app/(content)/feedback/components/ui/FeedbackSkeleton.tsx
+++ b/apps/admin/src/app/(content)/feedback/components/ui/FeedbackSkeleton.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from "@workspace/ui/components/skeleton";
+
+const FeedbackSkeleton = () => {
+  return (
+    <div className="space-y-4 px-4 py-8">
+      <Skeleton className="h-6 w-1/3" />
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full rounded-md" />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default FeedbackSkeleton;

--- a/apps/admin/src/components/providers.tsx
+++ b/apps/admin/src/components/providers.tsx
@@ -2,16 +2,30 @@
 
 import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = React.useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 60 * 5,
+            refetchOnWindowFocus: false,
+          },
+        },
+      })
+  );
   return (
-    <NextThemesProvider
-      attribute="class"
-      defaultTheme="light"
-      enableSystem={false}
-      disableTransitionOnChange
-    >
-      {children}
-    </NextThemesProvider>
+    <QueryClientProvider client={queryClient}>
+      <NextThemesProvider
+        attribute="class"
+        defaultTheme="light"
+        enableSystem={false}
+        disableTransitionOnChange
+      >
+        {children}
+      </NextThemesProvider>
+    </QueryClientProvider>
   );
 }

--- a/apps/admin/src/service/feedback.ts
+++ b/apps/admin/src/service/feedback.ts
@@ -1,0 +1,10 @@
+import api from "@api/http-commons";
+
+export const fetchFeedbackList = async (page: number) => {
+  const { data } = await api.get("/api/admin/feedback", {
+    params: {
+      page: page,
+    },
+  });
+  return data;
+};

--- a/apps/admin/src/types/feedback.ts
+++ b/apps/admin/src/types/feedback.ts
@@ -1,3 +1,5 @@
+import { ResponseStatus } from "./responseStatus";
+
 export interface Feedback {
   title: string;
   content: string;
@@ -10,4 +12,8 @@ export interface FeedbackData {
   content: Feedback[];
   totalCount: number;
   totalPages: number;
+}
+
+export interface FeedbackResponse extends ResponseStatus {
+  data: FeedbackData;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
 
   apps/admin:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.83.0
+        version: 5.83.0(react@19.1.0)
       '@workspace/ui':
         specifier: workspace:*
         version: link:../../packages/ui


### PR DESCRIPTION
## #️⃣연관된 이슈

> #174 

## 📝작업 내용

관리자 페이지에서 사용자의 피드백들을 열람할 수 있다.

피드백 타입 정의

피드백 리스트 서비스 구현

tanstack query provider로 layout을 감쌈

## 📷스크린샷 (선택)

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/70d122f1-7eae-478b-937d-2b003574bc67" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 피드백 목록이 이제 React Query를 통해 동적으로 불러와집니다.
  * 데이터 로딩 중에는 스켈레톤 UI가, 오류 발생 시에는 재시도 버튼이 있는 오류 메시지가 표시됩니다.

* **개선 사항**
  * 피드백 통계 컴포넌트가 전체 피드백 개수를 직접 받아 표시하도록 변경되었습니다.

* **기타**
  * 데이터 요청 및 상태 관리를 위한 React Query가 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->