### PR TITLE
[FEAT] UBLE-164 benefitCategory에 따른 제휴처 필터링 추가

### DIFF
--- a/apps/user/src/app/(main)/home/components/EntireSection.tsx
+++ b/apps/user/src/app/(main)/home/components/EntireSection.tsx
@@ -15,11 +15,13 @@ import ErrorState from "./ui/ErrorState";
 import EmptyState from "./ui/EmptyState";
 import { ALL_CATEGORY } from "@/types/constants";
 import { useRouter } from "next/navigation";
+import BenefitCategorySelector, { BenefitCategory } from "./ui/BenefitCategorySelector";
 
-const PAGE_SIZE = 8;
+const PAGE_SIZE = 9;
 
 export default function EntireSection() {
   const [categorys, setCategorys] = useState<Category>(ALL_CATEGORY);
+  const [benefitCategory, setBenefitCategory] = useState<BenefitCategory>(null);
   const router = useRouter();
 
   const params = useMemo<FetchBrandsParams>(
@@ -34,9 +36,10 @@ export default function EntireSection() {
           : categorys.categoryId === "LOCAL"
             ? "LOCAL"
             : undefined,
+      benefitCategory,
       size: PAGE_SIZE,
     }),
-    [categorys.categoryId]
+    [categorys.categoryId, benefitCategory]
   );
   const queryKey = useMemo(() => ["brands", params] as const, [params]);
 
@@ -62,6 +65,13 @@ export default function EntireSection() {
 
       <div className="pl-4 pr-4">
         <CategorySection selectedCategory={categorys} onSelectCategory={setCategorys} />
+      </div>
+
+      <div className="pl-4 pr-4">
+        <BenefitCategorySelector
+          selectedCategory={benefitCategory}
+          onSelectCategory={setBenefitCategory}
+        />
       </div>
 
       {isLoading && <LoadingState />}

--- a/apps/user/src/app/(main)/home/components/ui/BenefitCategorySelector.tsx
+++ b/apps/user/src/app/(main)/home/components/ui/BenefitCategorySelector.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Label } from "@workspace/ui/components/label";
+import { RadioGroup, RadioGroupItem } from "@workspace/ui/components/radio-group";
+
+export type BenefitCategory = null | "GIFT" | "DISCOUNT";
+
+interface BenefitCategorySelectorProps {
+  selectedCategory: BenefitCategory;
+  onSelectCategory: (category: BenefitCategory) => void;
+}
+
+export default function BenefitCategorySelector({
+  selectedCategory,
+  onSelectCategory,
+}: BenefitCategorySelectorProps) {
+  const categories = [
+    { value: "GIFT", label: "상품 증정" },
+    { value: "DISCOUNT", label: "할인 혜택" },
+  ] as const;
+
+  const handleValueChange = (value: string) => {
+    if (selectedCategory === value) {
+      onSelectCategory(null);
+    } else {
+      onSelectCategory(value as "GIFT" | "DISCOUNT");
+    }
+  };
+
+  return (
+    <div className="flex gap-4">
+      {categories.map((category) => (
+        <div
+          key={category.value}
+          className="flex cursor-pointer items-center space-x-2"
+          onClick={() => handleValueChange(category.value)}
+        >
+          <div
+            className={`flex h-5 w-5 items-center justify-center rounded-full border-2 ${
+              selectedCategory === category.value
+                ? "border-action-green bg-action-green"
+                : "border-gray-300"
+            }`}
+          >
+            {selectedCategory === category.value && (
+              <div className="h-2 w-2 rounded-full bg-white"></div>
+            )}
+          </div>
+          <Label className="cursor-pointer text-sm">{category.label}</Label>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/user/src/types/brand.ts
+++ b/apps/user/src/types/brand.ts
@@ -84,6 +84,7 @@ export interface FetchBrandsParams {
   categoryId?: number;
   season?: string;
   type?: string;
+  benefitCategory?: null | "GIFT" | "DISCOUNT";
   lastBrandId?: number;
   size?: number;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #199 

## 📝작업 내용

사용자는 상품 증정, 할인 혜택 중 하나를 골라서 해당하는 제휴처만 조회할 수 있다.

카테고리 바 하단에 상품 증정, 할인 혜택을 고를 수 있는 버튼 추가.

둘 중 하나만 고를 수 있으며 선택하지 않거나 사용자가 선택&해제할 수 있다.

## 📷스크린샷 (선택)

<img width="275" height="167" alt="image" src="https://github.com/user-attachments/assets/d799eaaa-0c84-43f6-9066-4cdc9defbb63" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 브랜드 목록에서 혜택 유형(선물, 할인)별로 필터링할 수 있는 선택 기능이 추가되었습니다.
  * 혜택 유형 선택 UI가 카테고리 아래에 새롭게 제공됩니다.

* **개선 사항**
  * 한 번에 표시되는 브랜드 수가 8개에서 9개로 늘어났습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->