### PR TITLE
[FEAT] UBLE-171 관리자 대시보드 구현

### DIFF
--- a/apps/admin/src/app/(content)/dashboard/components/DashboardProvider.tsx
+++ b/apps/admin/src/app/(content)/dashboard/components/DashboardProvider.tsx
@@ -1,46 +1,65 @@
-import React from "react";
+"use client";
 import DashboardContainer from "./DashboardContainer";
-import { StatCardData, RankItem } from "@/types/dashboard";
-
-// 예시 데이터
-const dashboardData: StatCardData = {
-  mau: 17,
-  lastMau: 23,
-  usageCount: 59,
-  lastUsageCount: 111,
-  totalBrandCount: 215,
-  totalStoreCount: 5641,
-};
-
-// 예시 차트 데이터
-const topUsageLocalList: RankItem[] = [
-  { name: "강남구", count: 7 },
-  { name: "광진구", count: 1 },
-];
-
-const topUsageRankList: RankItem[] = [
-  { name: "GS THE FRESH", count: 10 },
-  { name: "GS25", count: 7 },
-  { name: "다락", count: 4 },
-  { name: "롯데시네마", count: 2 },
-  { name: "쉐이크쉑", count: 1 },
-];
-
-// 예시 검색어 데이터
-const topSearchKeywordList: RankItem[] = [
-  { name: "바보", count: 83 },
-  { name: "씨지비", count: 7 },
-  { name: "GS25", count: 3 },
-  { name: "중구 병원", count: 3 },
-  { name: "카페", count: 3 },
-  { name: "할리스 강변역점", count: 3 },
-  { name: "강남 씨지비", count: 2 },
-  { name: "건", count: 2 },
-  { name: "건대", count: 2 },
-  { name: "바", count: 2 },
-];
+import DashboardSkeleton from "./ui/DashboardSkeleton";
+import { useQuery } from "@tanstack/react-query";
+import { fetchDashboardData } from "@/service/dashboard";
 
 const DashBoardProvider: React.FC = () => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["dashboard"],
+    queryFn: () => fetchDashboardData(),
+  });
+
+  // 로딩 상태일 때 스켈레톤 UI 표시
+  if (isLoading) {
+    return <DashboardSkeleton />;
+  }
+
+  // 에러 상태일 때 에러 메시지 표시
+  if (error) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="text-center">
+          <p className="text-lg font-semibold text-red-600">데이터를 불러오는데 실패했습니다.</p>
+          <p className="text-gray-600">잠시 후 다시 시도해 주세요.</p>
+        </div>
+      </div>
+    );
+  }
+
+  // 데이터가 없을 때
+  if (!data?.data) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="text-center">
+          <p className="text-lg font-semibold text-gray-600">데이터가 없습니다.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const {
+    mau,
+    lastMau,
+    usageCount,
+    lastUsageCount,
+    totalBrandCount,
+    totalStoreCount,
+    topUsageRankList,
+    topUsageLocalList,
+    topSearchKeywordList,
+  } = data.data;
+
+  // StatCardData 형태로 변환
+  const dashboardData = {
+    mau,
+    lastMau,
+    usageCount,
+    lastUsageCount,
+    totalBrandCount,
+    totalStoreCount,
+  };
+
   return (
     <DashboardContainer
       dashboardData={dashboardData}

--- a/apps/admin/src/app/(content)/dashboard/components/ui/ChartCard.tsx
+++ b/apps/admin/src/app/(content)/dashboard/components/ui/ChartCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card";
 
 interface ChartCardProps {
@@ -20,4 +20,4 @@ const ChartCard: React.FC<ChartCardProps> = ({ title, children, fixedHeight = tr
   );
 };
 
-export default ChartCard;
+export default memo(ChartCard);

--- a/apps/admin/src/app/(content)/dashboard/components/ui/DashboardSkeleton.tsx
+++ b/apps/admin/src/app/(content)/dashboard/components/ui/DashboardSkeleton.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { Card, CardContent, CardHeader } from "@workspace/ui/components/card";
+import { Skeleton } from "@workspace/ui/components/skeleton";
+
+const DashboardSkeleton: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      {/* 통계 카드 스켈레톤 */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <Card key={index} className="border-none">
+            <CardHeader className="pb-2">
+              <Skeleton className="h-4 w-24" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="mb-2 h-8 w-16" />
+              <Skeleton className="h-3 w-20" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* 차트 섹션 스켈레톤 */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <Card className="border-none">
+          <CardHeader>
+            <Skeleton className="h-6 w-32" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-64 w-full" />
+          </CardContent>
+        </Card>
+        <Card className="border-none">
+          <CardHeader>
+            <Skeleton className="h-6 w-32" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-64 w-full" />
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 검색어 테이블 스켈레톤 */}
+      <Card className="border-none">
+        <CardHeader>
+          <Skeleton className="h-6 w-40" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {Array.from({ length: 10 }).map((_, index) => (
+              <div key={index} className="flex items-center justify-between">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-16" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default DashboardSkeleton;

--- a/apps/admin/src/app/(content)/dashboard/components/ui/StatCard.tsx
+++ b/apps/admin/src/app/(content)/dashboard/components/ui/StatCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import { Card, CardContent } from "@workspace/ui/components/card";
 import { cn } from "@workspace/ui/lib/utils";
 import { LucideIcon } from "lucide-react";
@@ -109,4 +109,4 @@ const StatCard: React.FC<StatCardProps> = ({
   );
 };
 
-export default StatCard;
+export default memo(StatCard);

--- a/apps/admin/src/components/Header.tsx
+++ b/apps/admin/src/components/Header.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { Bell, Search, User, Menu } from "lucide-react";
+import { User, Menu } from "lucide-react";
 import { Button } from "@workspace/ui/components/button";
-import { Input } from "@workspace/ui/components/input";
 import { Avatar, AvatarFallback, AvatarImage } from "@workspace/ui/components/avatar";
 
 interface AdminHeaderProps {

--- a/apps/admin/src/components/LoginPage.tsx
+++ b/apps/admin/src/components/LoginPage.tsx
@@ -1,15 +1,15 @@
 "use client";
 import { User } from "lucide-react";
+import { toast } from "sonner";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 import { Button } from "@workspace/ui/components/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card";
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
-import { useState } from "react";
 import { apiHandler } from "@api/apiHandler";
 import { adminLogin } from "@/service/login";
-import { toast } from "sonner";
-import { useRouter } from "next/navigation";
 
 const LoginPage = () => {
   const [code, setCode] = useState<string>("");
@@ -21,7 +21,7 @@ const LoginPage = () => {
     const response = await apiHandler(() => adminLogin(code));
     if (response.data?.statusCode === 0) {
       toast.info("로그인 되었습니다.");
-      router.push("/statistics");
+      router.push("/dashboard");
     } else {
       toast.error("코드가 일치하지 않습니다.");
     }

--- a/apps/admin/src/service/dashboard.ts
+++ b/apps/admin/src/service/dashboard.ts
@@ -1,0 +1,7 @@
+import { DashboardResponse } from "@/types/dashboard";
+import api from "@api/http-commons";
+
+export const fetchDashboardData = async (): Promise<DashboardResponse> => {
+  const { data } = await api.get("api/admin/dashboard");
+  return data;
+};

--- a/apps/admin/src/types/dashboard.ts
+++ b/apps/admin/src/types/dashboard.ts
@@ -1,3 +1,5 @@
+import { ResponseStatus } from "./responseStatus";
+
 // 랭킹 아이템 기본 타입
 export interface RankItem {
   name: string;
@@ -21,7 +23,7 @@ export interface DashboardData {
 }
 
 // 대시보드 API 응답 타입
-export interface DashboardResponse {
+export interface DashboardResponse extends ResponseStatus {
   data: DashboardData;
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #211 

## 📝작업 내용

관리자 페이지 대시보드 구현.

로그인 성공 시 /dashboard로 redirect 됩니다.

불필요한 import를 삭제하였습니다.

dashboard 데이터 응답 타입 정의

dashboard 서비스 구현

tanstack query를 사용하여 데이터 fetching

loading skeleton 구현

## 📷스크린샷 (선택)

<img width="3840" height="1080" alt="image" src="https://github.com/user-attachments/assets/9aa9f8b3-0801-4b1e-ad54-248ebb4947aa" />

<img width="3840" height="1080" alt="image" src="https://github.com/user-attachments/assets/df708ae1-b0c9-4153-a6f8-e625fdc8e295" />

## 💬리뷰 요구사항(선택)

사진은 개발 서버의 응답으로 이루어진 화면으로 실제 서비스 서버의 데이터와 차이가 있습니다.