### PR TITLE
[FEAT] UBLE-178 카테고리 배치 변경

### DIFF
--- a/apps/user/src/constants/categoryMarkerStyle.tsx
+++ b/apps/user/src/constants/categoryMarkerStyle.tsx
@@ -73,7 +73,7 @@ const CATEGORY_META = {
   VIP콕: { icon: Gem, markerColor: "#7C3AED", textColor: "text-purple-600" },
   교육: { icon: GraduationCap, markerColor: "#FACC15", textColor: "text-yellow-500" },
   계절: { icon: Calendar, markerColor: "#22C55E", textColor: "text-green-500" },
-  우리동네멤버십: { icon: Users, markerColor: "#1E293B", textColor: "text-slate-700" },
+  우리동네멤버십: { icon: Users, markerColor: "#A16207", textColor: "text-amber-700" },
   default: { icon: Star, markerColor: "#94A3B8", textColor: "text-slate-500" },
 } as const;
 

--- a/apps/user/src/hooks/map/useHydrateCategories.ts
+++ b/apps/user/src/hooks/map/useHydrateCategories.ts
@@ -42,7 +42,6 @@ export const useHydrateCategories = () => {
           toast.error("카테고리를 불러오지 못했습니다.");
         }
         if (data?.categoryList) {
-          console.log(data.categoryList);
           // 카테고리를 우선순위 순서로 정렬
           const sortedCategories = sortCategoriesByPriority(data.categoryList);
 

--- a/apps/user/src/hooks/map/useHydrateCategories.ts
+++ b/apps/user/src/hooks/map/useHydrateCategories.ts
@@ -9,7 +9,7 @@ import { Category } from "@/types/category";
 /** 카테고리 우선순위 정렬 함수 */
 const sortCategoriesByPriority = (categories: Category[]): Category[] => {
   /** 우선순위 카테고리 배열 */
-  const priorityOrder = ["편의점", "카페", "식당", "영화관", "VIP콕"];
+  const priorityOrder = ["카페", "식당", "편의점", "영화관", "쇼핑"];
   const sortedCategories: Category[] = [];
   const remainingCategories: Category[] = [];
 

--- a/apps/user/src/hooks/map/useHydrateCategories.ts
+++ b/apps/user/src/hooks/map/useHydrateCategories.ts
@@ -4,6 +4,30 @@ import { apiHandler } from "@api/apiHandler";
 import { getCategories } from "@/service/category";
 import { ALL_CATEGORY, ANY_CATEGORIES } from "@/types/constants";
 import { toast } from "sonner";
+import { Category } from "@/types/category";
+
+/** 카테고리 우선순위 정렬 함수 */
+const sortCategoriesByPriority = (categories: Category[]): Category[] => {
+  /** 우선순위 카테고리 배열 */
+  const priorityOrder = ["편의점", "카페", "식당", "영화관", "VIP콕"];
+  const sortedCategories: Category[] = [];
+  const remainingCategories: Category[] = [];
+
+  priorityOrder.forEach((categoryName) => {
+    const category = categories.find((cat) => cat.categoryName === categoryName);
+    if (category) {
+      sortedCategories.push(category);
+    }
+  });
+
+  categories.forEach((category) => {
+    if (!priorityOrder.includes(category.categoryName)) {
+      remainingCategories.push(category);
+    }
+  });
+
+  return [...sortedCategories, ...remainingCategories];
+};
 
 export const useHydrateCategories = () => {
   const categories = useCategoryStore((s) => s.categories);
@@ -18,10 +42,14 @@ export const useHydrateCategories = () => {
           toast.error("카테고리를 불러오지 못했습니다.");
         }
         if (data?.categoryList) {
-          setUserCategories(data.categoryList);
+          console.log(data.categoryList);
+          // 카테고리를 우선순위 순서로 정렬
+          const sortedCategories = sortCategoriesByPriority(data.categoryList);
+
+          setUserCategories(sortedCategories);
           setCategories([
             ALL_CATEGORY,
-            ...data.categoryList.map((category) => ({ ...category })),
+            ...sortedCategories.map((category) => ({ ...category })),
             ...ANY_CATEGORIES,
           ]);
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #218 

## 📝작업 내용

카테고리의 순서를 사용량, 조회수 데이터 기준으로 재배치한다.
참고한 데이터는 다음과 같다.

<img width="1507" height="617" alt="image" src="https://github.com/user-attachments/assets/8f65e73b-502e-4388-b72a-4e77767eb205" />

<img width="1503" height="604" alt="image" src="https://github.com/user-attachments/assets/60f7dfbd-c2ec-4c0d-a3e5-4b556ae6f5a2" />

해당 통계를 바탕으로 카테고리의 우선순위를 다음과 같이 변경한다.

["카페", "식당", "편의점", "영화관", "쇼핑"]

우리동네멤버십의 경우 검은색 계열로 설정되어 있어 가시성이 떨어지는 문제가 있기에 갈색 계열로 변경하였다.

## 📷스크린샷 (선택)

<img width="284" height="64" alt="image" src="https://github.com/user-attachments/assets/4f3daac2-72b3-4f43-8ee4-85b49b3fa37e" />

<img width="183" height="57" alt="image" src="https://github.com/user-attachments/assets/856f8b42-ce8b-4889-9057-946dcfa41e3a" />

## 💬리뷰 요구사항(선택)

dev서버엔 편의점, 영화관 카테고리가 적용되어 있지 않아서 개발 서버 기준 사진을 첨부하였습니다.
우리동네멤버십의 색깔은 임의로 정하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * "우리동네멤버십" 카테고리의 마커 색상과 텍스트 색상이 진한 슬레이트 색상에서 앰버 색상으로 변경되었습니다.

* **기능 개선**
  * 카테고리 목록이 사전 정의된 우선순위(카페, 식당, 편의점, 영화관, 쇼핑)에 따라 정렬되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->