### PR TITLE
[FIX] UBLE-181 사용 내역 페이지 가드 분기

### DIFF
--- a/apps/user/src/app/(main)/mypage/history/components/BenefitList.tsx
+++ b/apps/user/src/app/(main)/mypage/history/components/BenefitList.tsx
@@ -58,9 +58,6 @@ const BenefitList = () => {
           {!user && (
             <div className="text-sm text-gray-500">로그인 후 이용 내역을 확인할 수 있습니다.</div>
           )}
-          {user && !userValidation.isValid && (
-            <div className="text-sm text-gray-500">마이페이지에서 프로필 정보를 완성해주세요.</div>
-          )}
         </div>
       </div>
     );

--- a/apps/user/src/app/(main)/mypage/history/components/BenefitList.tsx
+++ b/apps/user/src/app/(main)/mypage/history/components/BenefitList.tsx
@@ -7,12 +7,28 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { fetchUsageHistory } from "@/service/usage";
 import useInfiniteScroll from "@/hooks/useInfiniteScroll";
 import { UsageHistoryData, UsageHistoryResponse } from "@/types/usage";
+import useUserStore from "@/store/useUserStore";
+import { UserInfo } from "@/types/profile";
+
 const PAGE_SIZE = 10;
+
+// 유저 정보 검증 함수
+const validateUserInfo = (user: UserInfo | null) => {
+  if (!user) {
+    return { isValid: false, message: "로그인이 필요합니다." };
+  }
+
+  return { isValid: true, message: "" };
+};
 
 const BenefitList = () => {
   const now = new Date();
   const [year, setYear] = useState<number>(now.getFullYear());
   const [month, setMonth] = useState<number>(now.getMonth() + 1);
+  const { user } = useUserStore();
+
+  // 유저 정보 검증
+  const userValidation = validateUserInfo(user);
 
   const queryKey = useMemo(() => ["usageHistory", year, month] as const, [year, month]);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
@@ -26,11 +42,29 @@ const BenefitList = () => {
         return allPages.length;
       }) as any,
       initialPageParam: 0,
+      enabled: userValidation.isValid, // 유저 정보가 유효할 때만 쿼리 실행
     });
 
   const scrollRef = useInfiniteScroll({ hasNextPage: !!hasNextPage, fetchNextPage });
   const historyList = data?.pages ? data.pages.flatMap((page) => page.data.historyList ?? []) : [];
   const totalCount = data?.pages?.[0]?.data.totalCount ?? 0;
+
+  // 유저 정보가 유효하지 않은 경우
+  if (!userValidation.isValid) {
+    return (
+      <div className="flex flex-col items-center justify-center px-4 py-12">
+        <div className="text-center">
+          <div className="mb-2 text-lg font-semibold text-gray-900">{userValidation.message}</div>
+          {!user && (
+            <div className="text-sm text-gray-500">로그인 후 이용 내역을 확인할 수 있습니다.</div>
+          )}
+          {user && !userValidation.isValid && (
+            <div className="text-sm text-gray-500">마이페이지에서 프로필 정보를 완성해주세요.</div>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <Fragment>

--- a/apps/user/src/middleware.ts
+++ b/apps/user/src/middleware.ts
@@ -11,7 +11,6 @@ export const config = {
     "/mypage/history",
     "/partnerships",
     "/signup",
-    "/mypage/history",
   ],
 };
 

--- a/apps/user/src/middleware.ts
+++ b/apps/user/src/middleware.ts
@@ -11,6 +11,7 @@ export const config = {
     "/mypage/history",
     "/partnerships",
     "/signup",
+    "/mypage/history",
   ],
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #224 

## 📝작업 내용

/mypage/history에서 middleware가 실행됩니다.

유저 정보를 검증합니다.
유저 정보가 존재하지 않을 시 대체 UI가 출력됩니다.

## 📷스크린샷 (선택)

> 변경사항을 첨부해주세요

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 마이페이지 이용 내역에서 로그인하지 않은 사용자는 로그인 또는 프로필 완료를 안내하는 메시지가 표시됩니다.

* **Bug Fixes**
  * 일부 경로에 대한 접근 제어가 강화되어, 중복 경로가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->