### PR TITLE
[STYLE] 스타일 통일 및 실시간 검색어 기준 시각 정각으로 변경

### DIFF
--- a/apps/user/src/app/(main)/map/components/NaverMap.tsx
+++ b/apps/user/src/app/(main)/map/components/NaverMap.tsx
@@ -176,11 +176,9 @@ const NaverMap = forwardRef<NaverMapRef, NaverMapProps>(
     return (
       <div style={{ width: "100%", height: "100%", position: "relative" }}>
         {!isMapReady && (
-          <div className="absolute inset-0 z-50 flex items-center justify-center bg-white/80">
-            <div className="text-center text-gray-600">
-              <div className="mb-3 h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-blue-500" />
-              <div>지도를 불러오는 중...</div>
-            </div>
+          <div className="flex h-screen w-full flex-col items-center justify-center">
+            <div className="border-t-action-green mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-gray-300"></div>
+            <p className="text-gray-600">지도를 불러오는 중...</p>
           </div>
         )}
         <div id={mapId} style={{ width: "100%", height: "100%" }} />

--- a/apps/user/src/app/(main)/map/page.tsx
+++ b/apps/user/src/app/(main)/map/page.tsx
@@ -3,7 +3,14 @@ import { Suspense } from "react";
 
 export default function MapPage() {
   return (
-    <Suspense fallback={<div>로딩 중...</div>}>
+    <Suspense
+      fallback={
+        <div className="absolute inset-0 z-50 flex h-full w-full flex-col items-center justify-center gap-3">
+          <div className="border-t-action-green mb-3 h-10 w-10 animate-spin rounded-full border-4 border-gray-200" />
+          <div>로딩 중...</div>
+        </div>
+      }
+    >
       <MapContainer />
     </Suspense>
   );

--- a/apps/user/src/app/(main)/search/components/TrendingSearchesSection.tsx
+++ b/apps/user/src/app/(main)/search/components/TrendingSearchesSection.tsx
@@ -104,11 +104,7 @@ const TrendingSearchesSection = ({ onSearchClick }: TrendingSearchesSectionProps
       <div className="mb-3 flex items-center justify-between">
         <h3 className="text-sm font-semibold text-gray-900">실시간 인기 검색어</h3>
         <span className="text-xs text-gray-500">
-          {new Date().toLocaleTimeString("ko-KR", {
-            hour: "2-digit",
-            minute: "2-digit",
-          })}{" "}
-          기준
+          {`${String(new Date().getHours()).padStart(2, "0")}:00 기준`}
         </span>
       </div>
       {isLoading ? (


### PR DESCRIPTION
## #️⃣연관된 이슈

#239 

## 📝작업 내용

- 로딩 스피너 스타일 통일
- 실시간 검색어 기준 시각 정각으로 변경

## 📷스크린샷 (선택)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/34e1a4c2-f224-4883-a8a0-c681825178df" />

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 지도 로딩 화면의 스피너와 레이아웃이 변경되어 더 작고 녹색 테마의 스피너와 중앙 정렬된 레이아웃이 적용되었습니다.
  * 지도 페이지의 로딩 대기 화면이 텍스트에서 애니메이션 스피너와 스타일이 적용된 전체 화면 오버레이로 개선되었습니다.
* **기능 개선**
  * 실시간 인기 검색어 섹션에서 현재 시각 표기가 "시:00 기준" 형식(분 미표시)으로 단순화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->