### PR TITLE
[STYLE] UBLE-191 통계 카드 문구 수정, 필터 선택값 수정

### DIFF
--- a/apps/admin/src/app/(content)/dashboard/components/ChartSection.tsx
+++ b/apps/admin/src/app/(content)/dashboard/components/ChartSection.tsx
@@ -119,7 +119,7 @@ const ChartSection: React.FC<ChartSectionProps> = ({ topUsageLocalList, topUsage
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
       {/* 지역구 인기 순위 (파이 차트) */}
-      <ChartCard title="지역구 인기 순위">
+      <ChartCard title="Top 5 서울 지역구 인기 순위">
         {topUsageLocalList.length > 0 ? (
           <Pie data={pieChartData} options={pieOptions} />
         ) : (

--- a/apps/admin/src/app/(content)/dashboard/components/StatCards.tsx
+++ b/apps/admin/src/app/(content)/dashboard/components/StatCards.tsx
@@ -13,7 +13,7 @@ const StatCards: React.FC<StatCardsProps> = ({ dashboardData }) => {
       {/* 월간 활성 이용자 수 */}
       <StatCard
         icon={Users}
-        title="총 사용자 수"
+        title="이번달 활성 사용자 수"
         value={dashboardData.mau}
         previousValue={dashboardData.lastMau}
         subtitle="MAU"
@@ -27,7 +27,7 @@ const StatCards: React.FC<StatCardsProps> = ({ dashboardData }) => {
         title="이번 달 혜택 이용"
         value={dashboardData.usageCount}
         previousValue={dashboardData.lastUsageCount}
-        subtitle="이번 달"
+        subtitle="모든 유저"
         color="orange"
         showChange={true}
       />
@@ -47,7 +47,7 @@ const StatCards: React.FC<StatCardsProps> = ({ dashboardData }) => {
         icon={MapPin}
         title="전국 제휴처 매장 수"
         value={dashboardData.totalStoreCount}
-        subtitle="전국"
+        subtitle="스토어"
         color="blue"
         showChange={false}
       />

--- a/apps/admin/src/app/(content)/dashboard/components/ui/StatCard.tsx
+++ b/apps/admin/src/app/(content)/dashboard/components/ui/StatCard.tsx
@@ -87,9 +87,7 @@ const StatCard: React.FC<StatCardProps> = ({
         </div>
         <div>
           <p className="mb-1 text-sm font-medium text-gray-600">{title}</p>
-          <p className={cn("text-2xl font-bold md:text-4xl", classes.value)}>
-            {formatNumber(value)}
-          </p>
+          <p className={cn("text-2xl font-bold md:text-4xl", classes.value)}>{value}</p>
           {showChange && change && (
             <div className="mt-2 flex items-center">
               <span

--- a/apps/admin/src/types/constants.ts
+++ b/apps/admin/src/types/constants.ts
@@ -1,8 +1,8 @@
 export const filterOptions = {
   rankTarget: ["BRAND", "CATEGORY"] as const,
   gender: ["MALE", "FEMALE", null] as const,
-  ageRange: [10, 20, 30, 40, 50, 60, 70, 80, 90, null] as const,
-  rank: ["NONE", "NORMAL", "PREMIUM", "VIP", "VVIP", null] as const,
+  ageRange: [10, 20, 30, 40, 50, 60, 70, null] as const,
+  rank: ["NORMAL", "PREMIUM", "VIP", "VVIP", null] as const,
   benefitType: ["VIP", "LOCAL", "NORMAL", null] as const,
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #243 

## 📝작업 내용

통계 필터 "나이" 에서 80, 90 삭제, "등급" 에서 NONE 삭제

대시보드 통계 카드의 문구를 변경하였습니다.

## 📷스크린샷 (선택)

<img width="1543" height="798" alt="image" src="https://github.com/user-attachments/assets/7be88ccf-6742-425a-b362-b38f93545eed" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 대시보드 차트 카드 제목이 "지역구 인기 순위"에서 "Top 5 서울 지역구 인기 순위"로 변경되었습니다.
  * 통계 카드의 일부 제목과 부제목이 더 명확하게 수정되었습니다.

* **Bug Fixes**
  * 통계 카드에서 주요 값의 숫자 포맷팅이 제거되어, 원본 숫자가 그대로 표시됩니다.

* **Chores**
  * 연령대 필터에서 80, 90대 옵션이 제거되고, 회원 등급 필터에서 "NONE" 옵션이 삭제되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->