### PR TITLE
[FIX] UBLE-194 Next 이미지 허용 목록에 api.u-ble.com 추가

### DIFF
--- a/apps/user/next.config.mjs
+++ b/apps/user/next.config.mjs
@@ -30,6 +30,12 @@ const nextConfig = {
         protocol: "https",
         hostname: "uble-storage.s3.ap-northeast-2.amazonaws.com",
       },
+      {
+        protocol: "https",
+        hostname: "api.u-ble.com",
+        port: "",
+        pathname: "/logo/**",
+      },
     ],
   },
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #252 

## 📝작업 내용

next.config.mjs에 api.u-ble.com의 /logo 경로를 허용하도록 설정하였습니다.

## 📷스크린샷 (선택)

> 변경사항을 첨부해주세요

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 외부 도메인 api.u-ble.com의 /logo/** 이미지를 지원하여 앱 내 로고·브랜드 이미지가 안정적으로 표시됩니다. 기존 S3 이미지 지원은 그대로 유지됩니다.
  - 원격 이미지 허용 범위 확대로 로고 로딩 실패 가능성이 줄고, 브랜딩 요소 노출 일관성이 향상됩니다. 성능이나 사용자 설정에는 변화가 없으며, 기존 기능과의 호환성에 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->